### PR TITLE
Handle signal strengths when the strongest signal is constant

### DIFF
--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -82,6 +82,7 @@ Michael Killough
 Michaël Lefebvre
 Mike Popoloski
 Miodrag Milanović
+Mladen Slijepcevic
 Morten Borup Petersen
 Mostafa Gamal
 Nandu Raj

--- a/docs/guide/simulating.rst
+++ b/docs/guide/simulating.rst
@@ -7,9 +7,9 @@
 Simulating (Verilated-Model Runtime)
 ************************************
 
-This section describes items related to simulating, that using a Verilated
-model's executable.  For the runtime arguments to a simulated model, see
-:ref:`Simulation Runtime Arguments`.
+This section describes items related to simulating, that is, the use of a
+Verilated model's executable.  For the runtime arguments to a simulated
+model, see :ref:`Simulation Runtime Arguments`.
 
 
 .. _Benchmarking & Optimization:

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -446,21 +446,21 @@ static inline void VL_ASSIGNBIT_WO(int bit, WDataOutP owp) VL_MT_SAFE {
     { (vvar) = VL_CLEAN_QQ((obits), (obits), (svar).read().to_uint64()); }
 #define VL_ASSIGN_WSB(obits, owp, svar) \
     { \
-    const int words = VL_WORDS_I(obits); \
-    sc_biguint<(obits)> _butemp = (svar).read(); \
-    uint32_t* chunk = _butemp.get_raw(); \
-    int32_t lsb = 0; \
-    while (lsb < obits - BITS_PER_DIGIT) { \
-        const uint32_t data = *chunk; \
-        ++chunk; \
-        _vl_insert_WI(owp.data(), data, lsb+BITS_PER_DIGIT-1, lsb); \
-        lsb += BITS_PER_DIGIT; \
-    } \
-    if (lsb < obits) { \
-        const uint32_t msb_data = *chunk; \
-        _vl_insert_WI(owp.data(), msb_data, obits-1, lsb); \
-    } \
-    (owp)[words - 1] &= VL_MASK_E(obits); \
+        const int words = VL_WORDS_I(obits); \
+        sc_biguint<(obits)> _butemp = (svar).read(); \
+        uint32_t* chunk = _butemp.get_raw(); \
+        int32_t lsb = 0; \
+        while (lsb < obits - BITS_PER_DIGIT) { \
+            const uint32_t data = *chunk; \
+            ++chunk; \
+            _vl_insert_WI(owp.data(), data, lsb + BITS_PER_DIGIT - 1, lsb); \
+            lsb += BITS_PER_DIGIT; \
+        } \
+        if (lsb < obits) { \
+            const uint32_t msb_data = *chunk; \
+            _vl_insert_WI(owp.data(), msb_data, obits - 1, lsb); \
+        } \
+        (owp)[words - 1] &= VL_MASK_E(obits); \
     }
 
 // Copying verilog format from systemc integers and bit vectors.
@@ -499,24 +499,25 @@ static inline void VL_ASSIGNBIT_WO(int bit, WDataOutP owp) VL_MT_SAFE {
     { (svar).write(rd); }
 #define VL_ASSIGN_SBQ(obits, svar, rd) \
     { (svar).write(rd); }
-#define VL_SC_BITS_PER_DIGIT 30 // This comes from sc_nbdefs.h BITS_PER_DIGIT
+#define VL_SC_BITS_PER_DIGIT 30  // This comes from sc_nbdefs.h BITS_PER_DIGIT
 #define VL_ASSIGN_SBW(obits, svar, rwp) \
     { \
-    sc_biguint<(obits)> _butemp; \
-    int32_t lsb = 0; \
-    uint32_t* chunk = _butemp.get_raw(); \
-    while (lsb + VL_SC_BITS_PER_DIGIT < (obits)) { \
-        static_assert(std::is_same<IData, EData>::value, "IData and EData missmatch"); \
-        const uint32_t data = VL_SEL_IWII(lsb+VL_SC_BITS_PER_DIGIT+1, (rwp).data(), lsb, VL_SC_BITS_PER_DIGIT); \
-        *chunk = data & VL_MASK_E(VL_SC_BITS_PER_DIGIT); \
-        ++chunk; \
-        lsb += VL_SC_BITS_PER_DIGIT; \
-    } \
-    if (lsb < (obits)) { \
-        const uint32_t msb_data = VL_SEL_IWII((obits)+1, (rwp).data(), lsb, (obits) - lsb); \
-        *chunk = msb_data & VL_MASK_E((obits) - lsb); \
-    } \
-    (svar).write(_butemp); \
+        sc_biguint<(obits)> _butemp; \
+        int32_t lsb = 0; \
+        uint32_t* chunk = _butemp.get_raw(); \
+        while (lsb + VL_SC_BITS_PER_DIGIT < (obits)) { \
+            static_assert(std::is_same<IData, EData>::value, "IData and EData missmatch"); \
+            const uint32_t data = VL_SEL_IWII(lsb + VL_SC_BITS_PER_DIGIT + 1, (rwp).data(), lsb, \
+                                              VL_SC_BITS_PER_DIGIT); \
+            *chunk = data & VL_MASK_E(VL_SC_BITS_PER_DIGIT); \
+            ++chunk; \
+            lsb += VL_SC_BITS_PER_DIGIT; \
+        } \
+        if (lsb < (obits)) { \
+            const uint32_t msb_data = VL_SEL_IWII((obits) + 1, (rwp).data(), lsb, (obits)-lsb); \
+            *chunk = msb_data & VL_MASK_E((obits)-lsb); \
+        } \
+        (svar).write(_butemp); \
     }
 
 //===================================================================

--- a/include/verilated_funcs.h
+++ b/include/verilated_funcs.h
@@ -446,14 +446,21 @@ static inline void VL_ASSIGNBIT_WO(int bit, WDataOutP owp) VL_MT_SAFE {
     { (vvar) = VL_CLEAN_QQ((obits), (obits), (svar).read().to_uint64()); }
 #define VL_ASSIGN_WSB(obits, owp, svar) \
     { \
-        const int words = VL_WORDS_I(obits); \
-        sc_biguint<(obits)> _butemp = (svar).read(); \
-        for (int i = 0; i < words; ++i) { \
-            int msb = ((i + 1) * VL_IDATASIZE) - 1; \
-            msb = (msb >= (obits)) ? ((obits)-1) : msb; \
-            (owp)[i] = _butemp.range(msb, i * VL_IDATASIZE).to_uint(); \
-        } \
-        (owp)[words - 1] &= VL_MASK_E(obits); \
+    const int words = VL_WORDS_I(obits); \
+    sc_biguint<(obits)> _butemp = (svar).read(); \
+    uint32_t* chunk = _butemp.get_raw(); \
+    int32_t lsb = 0; \
+    while (lsb < obits - BITS_PER_DIGIT) { \
+        const uint32_t data = *chunk; \
+        ++chunk; \
+        _vl_insert_WI(owp.data(), data, lsb+BITS_PER_DIGIT-1, lsb); \
+        lsb += BITS_PER_DIGIT; \
+    } \
+    if (lsb < obits) { \
+        const uint32_t msb_data = *chunk; \
+        _vl_insert_WI(owp.data(), msb_data, obits-1, lsb); \
+    } \
+    (owp)[words - 1] &= VL_MASK_E(obits); \
     }
 
 // Copying verilog format from systemc integers and bit vectors.
@@ -492,15 +499,24 @@ static inline void VL_ASSIGNBIT_WO(int bit, WDataOutP owp) VL_MT_SAFE {
     { (svar).write(rd); }
 #define VL_ASSIGN_SBQ(obits, svar, rd) \
     { (svar).write(rd); }
+#define VL_SC_BITS_PER_DIGIT 30 // This comes from sc_nbdefs.h BITS_PER_DIGIT
 #define VL_ASSIGN_SBW(obits, svar, rwp) \
     { \
-        sc_biguint<(obits)> _butemp; \
-        for (int i = 0; i < VL_WORDS_I(obits); ++i) { \
-            int msb = ((i + 1) * VL_IDATASIZE) - 1; \
-            msb = (msb >= (obits)) ? ((obits)-1) : msb; \
-            _butemp.range(msb, i* VL_IDATASIZE) = (rwp)[i]; \
-        } \
-        (svar).write(_butemp); \
+    sc_biguint<(obits)> _butemp; \
+    int32_t lsb = 0; \
+    uint32_t* chunk = _butemp.get_raw(); \
+    while (lsb + VL_SC_BITS_PER_DIGIT < (obits)) { \
+        static_assert(std::is_same<IData, EData>::value, "IData and EData missmatch"); \
+        const uint32_t data = VL_SEL_IWII(lsb+VL_SC_BITS_PER_DIGIT+1, (rwp).data(), lsb, VL_SC_BITS_PER_DIGIT); \
+        *chunk = data & VL_MASK_E(VL_SC_BITS_PER_DIGIT); \
+        ++chunk; \
+        lsb += VL_SC_BITS_PER_DIGIT; \
+    } \
+    if (lsb < (obits)) { \
+        const uint32_t msb_data = VL_SEL_IWII((obits)+1, (rwp).data(), lsb, (obits) - lsb); \
+        *chunk = msb_data & VL_MASK_E((obits) - lsb); \
+    } \
+    (svar).write(_butemp); \
     }
 
 //===================================================================

--- a/src/V3Ast.cpp
+++ b/src/V3Ast.cpp
@@ -213,7 +213,7 @@ string AstNode::prettyTypeName() const {
 // Insertion
 
 inline void AstNode::debugTreeChange(const AstNode* nodep, const char* prefix, int lineno,
-                                     bool next){
+                                     bool next) {
 #ifdef VL_DEBUG
 // Called on all major tree changers.
 // Only for use for those really nasty bugs relating to internals
@@ -234,7 +234,8 @@ inline void AstNode::debugTreeChange(const AstNode* nodep, const char* prefix, i
 #endif
 }
 
-AstNode* AstNode::addNext(AstNode* nodep, AstNode* newp) {
+template <>
+AstNode* AstNode::addNext<AstNode, AstNode>(AstNode* nodep, AstNode* newp) {
     // Add to m_nextp, returns this
     UDEBUGONLY(UASSERT_OBJ(newp, nodep, "Null item passed to addNext"););
     debugTreeChange(nodep, "-addNextThs: ", __LINE__, false);
@@ -272,7 +273,8 @@ AstNode* AstNode::addNext(AstNode* nodep, AstNode* newp) {
     return nodep;
 }
 
-AstNode* AstNode::addNextNull(AstNode* nodep, AstNode* newp) {
+template <>
+AstNode* AstNode::addNextNull<AstNode, AstNode>(AstNode* nodep, AstNode* newp) {
     if (!newp) return nodep;
     return addNext(nodep, newp);
 }

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -1759,16 +1759,27 @@ public:
 
     // METHODS - Tree modifications
     // Returns nodep, adds newp to end of nodep's list
-    static AstNode* addNext(AstNode* nodep, AstNode* newp);
-    // Returns nodep, adds newp (maybe nullptr) to end of nodep's list
-    static AstNode* addNextNull(AstNode* nodep, AstNode* newp);
-    inline AstNode* addNext(AstNode* newp) { return addNext(this, newp); }
-    inline AstNode* addNextNull(AstNode* newp) { return addNextNull(this, newp); }
-    void addNextHere(AstNode* newp);  // Insert newp at this->nextp
-    void addPrev(AstNode* newp) {
-        replaceWith(newp);
-        newp->addNext(this);
+    template <typename T_NodeResult, typename T_NodeNext>
+    static T_NodeResult* addNext(T_NodeResult* nodep, T_NodeNext* newp) {
+        static_assert(std::is_base_of<AstNode, T_NodeResult>::value,
+                      "'T_NodeResult' must be a subtype of AstNode");
+        static_assert(std::is_base_of<T_NodeResult, T_NodeNext>::value,
+                      "'T_NodeNext' must be a subtype of 'T_NodeResult'");
+        return static_cast<T_NodeResult*>(addNext<AstNode, AstNode>(nodep, newp));
     }
+    // Returns nodep, adds newp (maybe nullptr) to end of nodep's list
+    template <typename T_NodeResult, typename T_NodeNext>
+    static T_NodeResult* addNextNull(T_NodeResult* nodep, T_NodeNext* newp) {
+        static_assert(std::is_base_of<AstNode, T_NodeResult>::value,
+                      "'T_NodeResult' must be a subtype of AstNode");
+        static_assert(std::is_base_of<T_NodeResult, T_NodeNext>::value,
+                      "'T_NodeNext' must be a subtype of 'T_NodeResult'");
+        return static_cast<T_NodeResult*>(addNextNull<AstNode, AstNode>(nodep, newp));
+    }
+    inline AstNode* addNext(AstNode* newp);
+    inline AstNode* addNextNull(AstNode* newp);
+    void addNextHere(AstNode* newp);  // Insert newp at this->nextp
+    inline void addPrev(AstNode* newp);
     void addHereThisAsNext(AstNode* newp);  // Adds at old place of this, this becomes next
     void replaceWith(AstNode* newp);  // Replace current node in tree with new node
     AstNode* unlinkFrBack(VNRelinker* linkerp
@@ -2055,6 +2066,12 @@ public:
         return count;
     }
 };
+
+// Forward declarations of specializations defined in V3Ast.cpp
+template <>
+AstNode* AstNode::addNext<AstNode, AstNode>(AstNode* nodep, AstNode* newp);
+template <>
+AstNode* AstNode::addNextNull<AstNode, AstNode>(AstNode* nodep, AstNode* newp);
 
 // Specialisations of privateTypeTest
 #include "V3Ast__gen_impl.h"  // From ./astgen

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -732,6 +732,10 @@ public:
         return (m_e == WIRE || m_e == WREAL || m_e == IMPLICITWIRE || m_e == TRIWIRE || m_e == TRI0
                 || m_e == TRI1 || m_e == PORT || m_e == SUPPLY0 || m_e == SUPPLY1 || m_e == VAR);
     }
+    bool isNet() const {
+        return (m_e == WIRE || m_e == IMPLICITWIRE || m_e == TRIWIRE || m_e == TRI0 || m_e == TRI1
+                || m_e == SUPPLY0 || m_e == SUPPLY1);
+    }
     bool isContAssignable() const {  // In Verilog, always ok in SystemVerilog
         return (m_e == SUPPLY0 || m_e == SUPPLY1 || m_e == WIRE || m_e == WREAL
                 || m_e == IMPLICITWIRE || m_e == TRIWIRE || m_e == TRI0 || m_e == TRI1
@@ -972,6 +976,32 @@ inline bool operator==(const VParseRefExp& lhs, const VParseRefExp& rhs) {
 inline bool operator==(const VParseRefExp& lhs, VParseRefExp::en rhs) { return lhs.m_e == rhs; }
 inline bool operator==(VParseRefExp::en lhs, const VParseRefExp& rhs) { return lhs == rhs.m_e; }
 inline std::ostream& operator<<(std::ostream& os, const VParseRefExp& rhs) {
+    return os << rhs.ascii();
+}
+
+//######################################################################
+
+class VStrength final {
+public:
+    enum en : uint8_t { HIGHZ, SMALL, MEDIUM, WEAK, LARGE, PULL, STRONG, SUPPLY };
+    enum en m_e;
+
+    inline VStrength(en strengthLevel)
+        : m_e(strengthLevel) {}
+    explicit inline VStrength(int _e)
+        : m_e(static_cast<en>(_e)) {}  // Need () or GCC 4.8 false warning
+
+    operator en() const { return m_e; }
+    const char* ascii() const {
+        static const char* const names[]
+            = {"highz", "small", "medium", "weak", "large", "pull", "strong", "supply"};
+        return names[m_e];
+    }
+};
+inline bool operator==(const VStrength& lhs, const VStrength& rhs) { return lhs.m_e == rhs.m_e; }
+inline bool operator==(const VStrength& lhs, VStrength::en rhs) { return lhs.m_e == rhs; }
+inline bool operator==(VStrength::en lhs, const VStrength& rhs) { return lhs == rhs.m_e; }
+inline std::ostream& operator<<(std::ostream& os, const VStrength& rhs) {
     return os << rhs.ascii();
 }
 

--- a/src/V3AstInlines.h
+++ b/src/V3AstInlines.h
@@ -23,7 +23,14 @@
 #endif
 
 //######################################################################
-// Inline ACCESSORS
+// Inline METHODS
+
+inline AstNode* AstNode::addNext(AstNode* newp) { return addNext(this, newp); }
+inline AstNode* AstNode::addNextNull(AstNode* newp) { return addNextNull(this, newp); }
+inline void AstNode::addPrev(AstNode* newp) {
+    replaceWith(newp);
+    newp->addNext(this);
+}
 
 inline int AstNode::width() const { return dtypep() ? dtypep()->width() : 0; }
 inline int AstNode::widthMin() const { return dtypep() ? dtypep()->widthMin() : 0; }

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -1786,6 +1786,10 @@ void AstSenItem::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     str << " [" << edgeType().ascii() << "]";
 }
+void AstStrengthSpec::dump(std::ostream& str) const {
+    this->AstNode::dump(str);
+    str << " (" << m_s0.ascii() << ", " << m_s1.ascii() << ")";
+}
 void AstParseRef::dump(std::ostream& str) const {
     this->AstNode::dump(str);
     str << " [" << expect().ascii() << "]";

--- a/src/V3AstNodes.h
+++ b/src/V3AstNodes.h
@@ -290,6 +290,23 @@ public:
     virtual bool same(const AstNode* /*samep*/) const override { return true; }
 };
 
+class AstStrengthSpec final : public AstNode {
+private:
+    VStrength m_s0;  // Drive 0 strength
+    VStrength m_s1;  // Drive 1 strength
+
+public:
+    AstStrengthSpec(FileLine* fl, VStrength s0, VStrength s1)
+        : ASTGEN_SUPER_StrengthSpec(fl)
+        , m_s0{s0}
+        , m_s1{s1} {}
+
+    ASTNODE_NODE_FUNCS(StrengthSpec)
+    VStrength strength0() { return m_s0; }
+    VStrength strength1() { return m_s1; }
+    virtual void dump(std::ostream& str) const override;
+};
+
 class AstGatePin final : public AstNodeMath {
     // Possibly expand a gate primitive input pin value to match the range of the gate primitive
 public:
@@ -2330,6 +2347,7 @@ public:
     bool isIfaceRef() const { return (varType() == VVarType::IFACEREF); }
     bool isIfaceParent() const { return m_isIfaceParent; }
     bool isSignal() const { return varType().isSignal(); }
+    bool isNet() const { return varType().isNet(); }
     bool isTemp() const { return varType().isTemp(); }
     bool isToggleCoverable() const {
         return ((isIO() || isSignal())
@@ -3630,6 +3648,8 @@ public:
     AstAssignW(FileLine* fl, AstNode* lhsp, AstNode* rhsp)
         : ASTGEN_SUPER_AssignW(fl, lhsp, rhsp) {}
     ASTNODE_NODE_FUNCS(AssignW)
+    AstStrengthSpec* strengthSpecp() const { return VN_AS(op4p(), StrengthSpec); }
+    void strengthSpecp(AstStrengthSpec* const strengthSpecp) { setOp4p((AstNode*)strengthSpecp); }
     virtual AstNode* cloneType(AstNode* lhsp, AstNode* rhsp) override {
         return new AstAssignW(this->fileline(), lhsp, rhsp);
     }

--- a/src/V3Const.cpp
+++ b/src/V3Const.cpp
@@ -2079,7 +2079,7 @@ private:
             AstSel* const sel2p = new AstSel(conp->fileline(), rhs2p, lsb2, msb2 - lsb2 + 1);
             // Make new assigns of same flavor as old one
             //*** Not cloneTree; just one node.
-            AstNode* newp = nullptr;
+            AstNodeAssign* newp = nullptr;
             if (!need_temp) {
                 AstNodeAssign* const asn1ap = VN_AS(nodep->cloneType(lc1p, sel1p), NodeAssign);
                 AstNodeAssign* const asn2ap = VN_AS(nodep->cloneType(lc2p, sel2p), NodeAssign);

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -67,10 +67,10 @@ void V3ParseImp::parserClear() {
 //======================================================================
 // V3ParseGrammar functions requiring bison state
 
-AstNode* V3ParseGrammar::argWrapList(AstNode* nodep) {
+AstArg* V3ParseGrammar::argWrapList(AstNode* nodep) {
     // Convert list of expressions to list of arguments
     if (!nodep) return nullptr;
-    AstNode* outp = nullptr;
+    AstArg* outp = nullptr;
     AstBegin* const tempp = new AstBegin(nodep->fileline(), "[EditWrapper]", nodep);
     while (nodep) {
         AstNode* const nextp = nodep->nextp();

--- a/src/V3ParseGrammar.cpp
+++ b/src/V3ParseGrammar.cpp
@@ -84,9 +84,13 @@ AstArg* V3ParseGrammar::argWrapList(AstNode* nodep) {
 }
 
 AstNode* V3ParseGrammar::createSupplyExpr(FileLine* fileline, const string& name, int value) {
-    return new AstAssignW(
-        fileline, new AstVarRef(fileline, name, VAccess::WRITE),
-        new AstConst(fileline, AstConst::StringToParse(), (value ? "'1" : "'0")));
+    AstAssignW* assignp
+        = new AstAssignW{fileline, new AstVarRef{fileline, name, VAccess::WRITE},
+                         new AstConst{fileline, AstConst::StringToParse{}, (value ? "'1" : "'0")}};
+    AstStrengthSpec* strengthSpecp
+        = new AstStrengthSpec{fileline, VStrength::SUPPLY, VStrength::SUPPLY};
+    assignp->strengthSpecp(strengthSpecp);
+    return assignp;
 }
 
 AstRange* V3ParseGrammar::scrubRange(AstNodeRange* nrangep) {

--- a/src/V3ParseImp.cpp
+++ b/src/V3ParseImp.cpp
@@ -398,8 +398,7 @@ void V3ParseImp::tokenPipeline() {
         const int nexttok = nexttokp->token;
         yylval = curValue;
         // Now potentially munge the current token
-        if (token == '('
-            && (nexttok == ygenSTRENGTH || nexttok == ySUPPLY0 || nexttok == ySUPPLY1)) {
+        if (token == '(' && isStrengthToken(nexttok)) {
             token = yP_PAR__STRENGTH;
         } else if (token == ':') {
             if (nexttok == yBEGIN) {
@@ -481,6 +480,12 @@ void V3ParseImp::tokenPipeline() {
     }
     yylval.token = token;
     // effectively returns yylval
+}
+
+bool V3ParseImp::isStrengthToken(int tok) {
+    return tok == ygenSTRENGTH || tok == ySUPPLY0 || tok == ySUPPLY1 || tok == ySTRONG0
+           || tok == ySTRONG1 || tok == yPULL0 || tok == yPULL1 || tok == yWEAK0 || tok == yWEAK1
+           || tok == yHIGHZ0 || tok == yHIGHZ1;
 }
 
 void V3ParseImp::tokenPipelineSym() {

--- a/src/V3ParseImp.h
+++ b/src/V3ParseImp.h
@@ -121,6 +121,7 @@ struct V3ParseBisonYYSType {
         V3ErrorCode::en errcodeen;
         VAttrType::en attrtypeen;
         VLifetime::en lifetime;
+        VStrength::en strength;
 
 #include "V3Ast__gen_yystype.h"
     };
@@ -216,6 +217,7 @@ public:
     }
     int lexKwdLastState() const { return m_lexKwdLast; }
     static const char* tokenName(int tok);
+    static bool isStrengthToken(int tok);
 
     void ppPushText(const string& text) {
         m_ppBuffers.push_back(text);

--- a/src/V3Slice.cpp
+++ b/src/V3Slice.cpp
@@ -139,12 +139,13 @@ class SliceVisitor final : public VNVisitor {
                 // Left and right could have different msb/lsbs/endianness, but #elements is common
                 // and all variables are realigned to start at zero
                 // Assign of a little endian'ed slice to a big endian one must reverse the elements
-                AstNode* newlistp = nullptr;
+                AstNodeAssign* newlistp = nullptr;
                 const int elements = arrayp->rangep()->elementsConst();
                 for (int offset = 0; offset < elements; ++offset) {
-                    AstNode* const newp = nodep->cloneType  // AstNodeAssign
-                                          (cloneAndSel(nodep->lhsp(), elements, offset),
-                                           cloneAndSel(nodep->rhsp(), elements, offset));
+                    AstNodeAssign* const newp
+                        = VN_AS(nodep->cloneType(cloneAndSel(nodep->lhsp(), elements, offset),
+                                                 cloneAndSel(nodep->rhsp(), elements, offset)),
+                                NodeAssign);
                     if (debug() >= 9) newp->dumpTree(cout, "-new ");
                     newlistp = AstNode::addNextNull(newlistp, newp);
                 }

--- a/src/V3Undriven.cpp
+++ b/src/V3Undriven.cpp
@@ -30,6 +30,7 @@
 
 #include "V3Ast.h"
 #include "V3Global.h"
+#include "V3Stats.h"
 #include "V3String.h"
 
 #include <algorithm>
@@ -475,4 +476,5 @@ public:
 void V3Undriven::undrivenAll(AstNetlist* nodep) {
     UINFO(2, __FUNCTION__ << ": " << endl);
     { UndrivenVisitor{nodep}; }
+    if (v3Global.opt.stats()) V3Stats::statsStage("undriven");
 }

--- a/src/verilog.l
+++ b/src/verilog.l
@@ -325,8 +325,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "forever"             { FL; return yFOREVER; }
   "fork"                { FL; return yFORK; }
   "function"            { FL; return yFUNCTION; }
-  "highz0"              { FL; return ygenSTRENGTH; }
-  "highz1"              { FL; return ygenSTRENGTH; }
+  "highz0"              { FL; return yHIGHZ0; }
+  "highz1"              { FL; return yHIGHZ1; }
   "if"                  { FL; return yIF; }
   "initial"             { FL; return yINITIAL; }
   "inout"               { FL; return yINOUT; }
@@ -350,8 +350,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "pmos"                { FL; return yPMOS; }
   "posedge"             { FL; return yPOSEDGE; }
   "primitive"           { FL; return yPRIMITIVE; }
-  "pull0"               { FL; return ygenSTRENGTH; }
-  "pull1"               { FL; return ygenSTRENGTH; }
+  "pull0"               { FL; return yPULL0; }
+  "pull1"               { FL; return yPULL1; }
   "pulldown"            { FL; return yPULLDOWN; }
   "pullup"              { FL; return yPULLUP; }
   "rcmos"               { FL; return yRCMOS; }
@@ -369,8 +369,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "small"               { FL; return ygenSTRENGTH; }
   "specify"             { FL; return ySPECIFY; }
   "specparam"           { FL; return ySPECPARAM; }
-  "strong0"             { FL; return ygenSTRENGTH; }
-  "strong1"             { FL; return ygenSTRENGTH; }
+  "strong0"             { FL; return ySTRONG0; }
+  "strong1"             { FL; return ySTRONG1; }
   "supply0"             { FL; return ySUPPLY0; }
   "supply1"             { FL; return ySUPPLY1; }
   "table"               { FL; yy_push_state(TABLE); return yTABLE; }
@@ -388,8 +388,8 @@ vnum    {vnum1}|{vnum2}|{vnum3}|{vnum4}|{vnum5}
   "vectored"            { FL; return yVECTORED; }
   "wait"                { FL; return yWAIT; }
   "wand"                { FL; return yWAND; }
-  "weak0"               { FL; return ygenSTRENGTH; }
-  "weak1"               { FL; return ygenSTRENGTH; }
+  "weak0"               { FL; return yWEAK0; }
+  "weak1"               { FL; return yWEAK1; }
   "while"               { FL; return yWHILE; }
   "wire"                { FL; return yWIRE; }
   "wor"                 { FL; return yWOR; }

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -91,7 +91,7 @@ public:
     }
 
     // METHODS
-    AstNode* argWrapList(AstNode* nodep);
+    AstArg* argWrapList(AstNode* nodep);
     bool allTracingOn(FileLine* fl) {
         return v3Global.opt.trace() && m_tracingParse && fl->tracingOn();
     }
@@ -5103,7 +5103,7 @@ idArrayedForeach<nodep>:        // IEEE: id + select (under foreach expression)
         |       idArrayed '[' expr ',' loop_variables ']'
                         { $3 = AstNode::addNextNull($3, $5); $$ = new AstSelLoopVars($2, $1, $3); }
         |       idArrayed '[' ',' loop_variables ']'
-                        { $4 = AstNode::addNextNull(new AstEmpty{$3}, $4); $$ = new AstSelLoopVars($2, $1, $4); }
+                        { $4 = AstNode::addNextNull(static_cast<AstNode*>(new AstEmpty{$3}), $4); $$ = new AstSelLoopVars($2, $1, $4); }
         ;
 
 // VarRef without any dots or vectorizaion

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -40,6 +40,13 @@
 #define BBUNSUP(fl, msg) (fl)->v3warn(E_UNSUPPORTED, msg)
 #define GATEUNSUP(fl, tok) \
     { BBUNSUP((fl), "Unsupported: Verilog 1995 gate primitive: " << (tok)); }
+#define STRENGTHUNSUP(nodep) \
+    { \
+        if (nodep) { \
+            BBUNSUP((nodep->fileline()), "Unsupported: Strength specifier on this gate type"); \
+            nodep->deleteTree(); \
+        } \
+    }
 #define PRIMDLYUNSUP(nodep) \
     { \
         if (nodep) { \
@@ -68,6 +75,7 @@ public:
     AstNodeDType* m_varDTypep = nullptr;  // Pointer to data type for next signal declaration
     AstNodeDType* m_memDTypep = nullptr;  // Pointer to data type for next member declaration
     AstNode* m_netDelayp = nullptr;  // Pointer to delay for next signal declaration
+    AstStrengthSpec* m_netStrengthp = nullptr;  // Pointer to strength for next net declaration
     AstNodeModule* m_modp = nullptr;  // Last module for timeunits
     bool m_pinAnsi = false;  // In ANSI port list
     FileLine* m_instModuleFl = nullptr;  // Fileline of module referenced for instantiations
@@ -172,6 +180,7 @@ public:
         m_varDTypep = dtypep;
     }
     void setNetDelay(AstNode* netDelayp) { m_netDelayp = netDelayp; }
+    void setNetStrength(AstStrengthSpec* netStrengthp) { m_netStrengthp = netStrengthp; }
     void pinPush() {
         m_pinStack.push(m_pinNum);
         m_pinNum = 1;
@@ -289,6 +298,15 @@ int V3ParseGrammar::s_modTypeImpNum = 0;
 #define DEL(nodep) \
     { \
         if (nodep) nodep->deleteTree(); \
+    }
+
+#define APPLY_STRENGTH_TO_LIST(beginp, strengthSpecNodep, typeToCast) \
+    { \
+        if (AstStrengthSpec* specp = VN_CAST(strengthSpecNodep, StrengthSpec)) \
+            for (auto* nodep = beginp; nodep; nodep = nodep->nextp()) { \
+                auto* const assignp = VN_AS(nodep, typeToCast); \
+                assignp->strengthSpecp(nodep == beginp ? specp : specp->cloneTree(false)); \
+            } \
     }
 
 static void ERRSVKWD(FileLine* fileline, const string& tokname) {
@@ -544,6 +562,8 @@ BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
 %token<fl>              yGLOBAL__CLOCKING "global-then-clocking"
 %token<fl>              yGLOBAL__ETC    "global"
 %token<fl>              yGLOBAL__LEX    "global-in-lex"
+%token<fl>              yHIGHZ0         "highz0"
+%token<fl>              yHIGHZ1         "highz1"
 %token<fl>              yIF             "if"
 %token<fl>              yIFF            "iff"
 //UNSUP %token<fl>      yIGNORE_BINS    "ignore_bins"
@@ -598,6 +618,8 @@ BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
 %token<fl>              yPROGRAM        "program"
 %token<fl>              yPROPERTY       "property"
 %token<fl>              yPROTECTED      "protected"
+%token<fl>              yPULL0          "pull0"
+%token<fl>              yPULL1          "pull1"
 %token<fl>              yPULLDOWN       "pulldown"
 %token<fl>              yPULLUP         "pullup"
 %token<fl>              yPURE           "pure"
@@ -635,6 +657,8 @@ BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
 %token<fl>              ySTATIC__LEX    "static-in-lex"
 %token<fl>              ySTRING         "string"
 //UNSUP %token<fl>      ySTRONG         "strong"
+%token<fl>              ySTRONG0        "strong0"
+%token<fl>              ySTRONG1        "strong1"
 %token<fl>              ySTRUCT         "struct"
 %token<fl>              ySUPER          "super"
 %token<fl>              ySUPPLY0        "supply0"
@@ -688,6 +712,8 @@ BISONPRE_VERSION(3.7,%define api.header.include {"V3ParseBison.h"})
 //UNSUP %token<fl>      yWAIT_ORDER     "wait_order"
 %token<fl>              yWAND           "wand"
 //UNSUP %token<fl>      yWEAK           "weak"
+%token<fl>              yWEAK0          "weak0"
+%token<fl>              yWEAK1          "weak1"
 %token<fl>              yWHILE          "while"
 //UNSUP %token<fl>      yWILDCARD       "wildcard"
 %token<fl>              yWIRE           "wire"
@@ -1718,11 +1744,18 @@ parameter_port_declarationTypeFrontE: // IEEE: parameter_port_declaration w/o as
         ;
 
 net_declaration<nodep>:         // IEEE: net_declaration - excluding implict
-                net_declarationFront netSigList ';'     { $$ = $2; }
+                net_declarationFront netSigList ';'
+                        { $$ = $2;
+                          if (GRAMMARP->m_netStrengthp) {
+                              VL_DO_CLEAR(delete GRAMMARP->m_netStrengthp, GRAMMARP->m_netStrengthp = nullptr);
+                          }}
         ;
 
 net_declarationFront:           // IEEE: beginning of net_declaration
-                net_declRESET net_type   strengthSpecE net_scalaredE net_dataTypeE { VARDTYPE_NDECL($5); }
+                net_declRESET net_type driveStrengthE net_scalaredE net_dataTypeE
+                        { VARDTYPE_NDECL($5);
+                          GRAMMARP->setNetStrength(VN_CAST($3, StrengthSpec));
+                        }
         //UNSUP net_declRESET yINTERCONNECT signingE rangeListE { VARNET($2); VARDTYPE(x); }
         ;
 
@@ -2425,9 +2458,10 @@ module_common_item<nodep>:      // ==IEEE: module_common_item
         ;
 
 continuous_assign<nodep>:       // IEEE: continuous_assign
-                yASSIGN strengthSpecE delayE assignList ';'
+                yASSIGN driveStrengthE delayE assignList ';'
                 {
                     $$ = $4;
+                    APPLY_STRENGTH_TO_LIST($$, $2, AssignW);
                     if ($3)
                         for (auto* nodep = $$; nodep; nodep = nodep->nextp()) {
                             auto* const assignp = VN_AS(nodep, NodeAssign);
@@ -2726,6 +2760,7 @@ netSig<varp>:                   // IEEE: net_decl_assignment -  one element from
         |       netId sigAttrListE '=' expr
                         { $$ = VARDONEA($<fl>1, *$1, nullptr, $2);
                           auto* const assignp = new AstAssignW{$3, new AstVarRef{$<fl>1, *$1, VAccess::WRITE}, $4};
+                          if (GRAMMARP->m_netStrengthp) assignp->strengthSpecp(GRAMMARP->m_netStrengthp->cloneTree(false));
                           if ($$->delayp()) assignp->addTimingControlp($$->delayp()->unlinkFrBack());  // IEEE 1800-2017 10.3.3
                           $$->addNext(assignp); }        |       netId variable_dimensionList sigAttrListE
                         { $$ = VARDONEA($<fl>1,*$1, $2, $3); }
@@ -4718,18 +4753,30 @@ stream_expressionOrDataType<nodep>:     // IEEE: from streaming_concatenation
 // Gate declarations
 
 gateDecl<nodep>:
-                yBUF    delayE gateBufList ';'          { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yBUFIF0 delayE gateBufif0List ';'       { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yBUFIF1 delayE gateBufif1List ';'       { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yNOT    delayE gateNotList ';'          { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yNOTIF0 delayE gateNotif0List ';'       { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yNOTIF1 delayE gateNotif1List ';'       { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yAND  delayE gateAndList ';'            { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yNAND delayE gateNandList ';'           { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yOR   delayE gateOrList ';'             { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yNOR  delayE gateNorList ';'            { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yXOR  delayE gateXorList ';'            { $$ = $3; PRIMDLYUNSUP($2); }
-        |       yXNOR delayE gateXnorList ';'           { $$ = $3; PRIMDLYUNSUP($2); }
+                yBUF    driveStrengthE delayE gateBufList ';'
+                       { $$ = $4; STRENGTHUNSUP($2); PRIMDLYUNSUP($3); }
+        |       yBUFIF0 driveStrengthE delayE gateBufif0List ';'
+                       { $$ = $4; STRENGTHUNSUP($2); PRIMDLYUNSUP($3); }
+        |       yBUFIF1 driveStrengthE delayE gateBufif1List ';'
+                       { $$ = $4; STRENGTHUNSUP($2); PRIMDLYUNSUP($3); }
+        |       yNOT    driveStrengthE delayE gateNotList ';'
+                       { $$ = $4; APPLY_STRENGTH_TO_LIST($$, $2, AssignW); PRIMDLYUNSUP($3); }
+        |       yNOTIF0 driveStrengthE delayE gateNotif0List ';'
+                       { $$ = $4; STRENGTHUNSUP($2); PRIMDLYUNSUP($3); }
+        |       yNOTIF1 driveStrengthE delayE gateNotif1List ';'
+                       { $$ = $4; STRENGTHUNSUP($2); PRIMDLYUNSUP($3); }
+        |       yAND  driveStrengthE delayE gateAndList ';'
+                       { $$ = $4; APPLY_STRENGTH_TO_LIST($$, $2, AssignW); PRIMDLYUNSUP($3); }
+        |       yNAND driveStrengthE delayE gateNandList ';'
+                       { $$ = $4; APPLY_STRENGTH_TO_LIST($$, $2, AssignW); PRIMDLYUNSUP($3); }
+        |       yOR   driveStrengthE delayE gateOrList ';'
+                       { $$ = $4; APPLY_STRENGTH_TO_LIST($$, $2, AssignW); PRIMDLYUNSUP($3); }
+        |       yNOR  driveStrengthE delayE gateNorList ';'
+                       { $$ = $4; APPLY_STRENGTH_TO_LIST($$, $2, AssignW); PRIMDLYUNSUP($3); }
+        |       yXOR  driveStrengthE delayE gateXorList ';'
+                       { $$ = $4; APPLY_STRENGTH_TO_LIST($$, $2, AssignW); PRIMDLYUNSUP($3); }
+        |       yXNOR driveStrengthE delayE gateXnorList ';'
+                       { $$ = $4; APPLY_STRENGTH_TO_LIST($$, $2, AssignW); PRIMDLYUNSUP($3); }
         |       yPULLUP delayE gatePullupList ';'       { $$ = $3; PRIMDLYUNSUP($2); }
         |       yPULLDOWN delayE gatePulldownList ';'   { $$ = $3; PRIMDLYUNSUP($2); }
         |       yNMOS delayE gateBufif1List ';'         { $$ = $3; PRIMDLYUNSUP($2); }  // ~=bufif1, as don't have strengths yet
@@ -4901,21 +4948,33 @@ gatePinExpr<nodep>:
                 expr                                    { $$ = GRAMMARP->createGatePin($1); }
         ;
 
-// This list is also hardcoded in VParseLex.l
-strength:                       // IEEE: strength0+strength1 - plus HIGHZ/SMALL/MEDIUM/LARGE
-                ygenSTRENGTH                            { BBUNSUP($1, "Unsupported: Verilog 1995 strength specifiers"); }
-        |       ySUPPLY0                                { BBUNSUP($1, "Unsupported: Verilog 1995 strength specifiers"); }
-        |       ySUPPLY1                                { BBUNSUP($1, "Unsupported: Verilog 1995 strength specifiers"); }
+strength0<strength>:
+                ySUPPLY0                                { $$ = VStrength::SUPPLY; }
+        |       ySTRONG0                                { $$ = VStrength::STRONG; }
+        |       yPULL0                                  { $$ = VStrength::PULL; }
+        |       yWEAK0                                  { $$ = VStrength::WEAK; }
         ;
 
-strengthSpecE:                  // IEEE: drive_strength + pullup_strength + pulldown_strength + charge_strength - plus empty
-                /* empty */                             { }
-        |       strengthSpec                            { }
+strength1<strength>:
+                ySUPPLY1                                { $$ = VStrength::SUPPLY; }
+        |       ySTRONG1                                { $$ = VStrength::STRONG; }
+        |       yPULL1                                  { $$ = VStrength::PULL; }
+        |       yWEAK1                                  { $$ = VStrength::WEAK; }
         ;
 
-strengthSpec:                   // IEEE: drive_strength + pullup_strength + pulldown_strength + charge_strength - plus empty
-                yP_PAR__STRENGTH strength ')'                   { }
-        |       yP_PAR__STRENGTH strength ',' strength ')'      { }
+driveStrengthE<nodep>:
+/* empty */                                             { $$ = nullptr; }
+        |       driveStrength                           { $$ = $1; }
+        ;
+
+
+driveStrength<nodep>:
+                yP_PAR__STRENGTH strength0 ',' strength1 ')' { $$ = new AstStrengthSpec{$1, $2, $4}; }
+        |       yP_PAR__STRENGTH strength1 ',' strength0 ')' { $$ = new AstStrengthSpec{$1, $4, $2}; }
+        |       yP_PAR__STRENGTH strength0 ',' yHIGHZ1 ')' { BBUNSUP($<fl>4, "Unsupported: highz strength"); }
+        |       yP_PAR__STRENGTH strength1 ',' yHIGHZ0 ')' { BBUNSUP($<fl>4, "Unsupported: highz strength"); }
+        |       yP_PAR__STRENGTH yHIGHZ0 ',' strength1 ')' { BBUNSUP($<fl>2, "Unsupported: highz strength"); }
+        |       yP_PAR__STRENGTH yHIGHZ1 ',' strength0 ')' { BBUNSUP($<fl>2, "Unsupported: highz strength"); }
         ;
 
 //************************************************

--- a/test_regress/t/t_EXAMPLE.v
+++ b/test_regress/t/t_EXAMPLE.v
@@ -13,7 +13,7 @@
 // please note it here, otherwise:**
 //
 // This file ONLY is placed under the Creative Commons Public Domain, for
-// any use, without warranty, 2022 by ____YOUR_NAME_HERE____.
+// any use, without warranty, 2022 by Wilson Snyder.
 // SPDX-License-Identifier: CC0-1.0
 
 module t(/*AUTOARG*/

--- a/test_regress/t/t_bitsel_wire_array_bad.out
+++ b/test_regress/t/t_bitsel_wire_array_bad.out
@@ -1,5 +1,4 @@
 %Error: t/t_bitsel_wire_array_bad.v:21:16: Illegal assignment of constant to unpacked array
-                                         : ... In instance t
    21 |    assign b = a[0];   
       |                ^
 %Error: Exiting due to

--- a/test_regress/t/t_split_var_1_bad.out
+++ b/test_regress/t/t_split_var_1_bad.out
@@ -23,10 +23,6 @@
                                            : ... In instance t
    41 |       i_sub0.cannot_split1[1] = bad_func(addr, rd_data0);
       |                               ^
-%Error: t/t_split_var_1_bad.v:79:16: Illegal assignment of constant to unpacked array
-                                   : ... In instance t.i_sub2
-   79 |    assign b = a[0];   
-      |                ^
 %Warning-SPLITVAR: t/t_split_var_1_bad.v:56:31: 'cannot_split0' has split_var metacomment but will not be split because index cannot be determined statically.
                                               : ... In instance t.i_sub0
    56 |       rd_data = cannot_split0[addr];
@@ -75,4 +71,16 @@
                                               : ... In instance t.i_sub1
    66 |       rd_data = rd_tmp[{3'b0, addr[0]}+:8];
       |                       ^
+%Error: t/t_split_var_1_bad.v:78:11: Illegal assignment of constant to unpacked array
+                                   : ... In instance t
+   78 |    assign a = 1'b0;   
+      |           ^
+%Error: t/t_split_var_1_bad.v:79:16: VARREF 'i_sub2.a(0)' is not an unpacked array, but is in an unpacked array context
+                                   : ... In instance t
+   79 |    assign b = a[0];   
+      |                ^
+%Error: t/t_split_var_1_bad.v:78:15: CONST '1'h0' is not an unpacked array, but is in an unpacked array context
+                                   : ... In instance t
+   78 |    assign a = 1'b0;   
+      |               ^~~~
 %Error: Exiting due to

--- a/test_regress/t/t_strength_2_assignments.pl
+++ b/test_regress/t/t_strength_2_assignments.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_2_assignments.v
+++ b/test_regress/t/t_strength_2_assignments.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire (weak0, weak1) a = 1;
+   assign (strong0, strong1) a = 0;
+
+   always begin
+      if (!a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_3_assignments.pl
+++ b/test_regress/t/t_strength_3_assignments.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_3_assignments.v
+++ b/test_regress/t/t_strength_3_assignments.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire a;
+   assign (weak0, weak1) a = 1;
+   assign (weak0, supply1) a = 1;
+   assign (strong0, strong1) a = 0;
+
+   always begin
+      if (a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_3_assignments_net_array.pl
+++ b/test_regress/t/t_strength_3_assignments_net_array.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_3_assignments_net_array.v
+++ b/test_regress/t/t_strength_3_assignments_net_array.v
@@ -1,0 +1,19 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire [31:0] a;
+   assign (weak0, weak1) a = '1;
+   assign (weak0, supply1) a = '1;
+   assign (strong0, strong1) a = '0;
+
+   always begin
+      if (a == '1) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_assign_to_supply_net.pl
+++ b/test_regress/t/t_strength_assign_to_supply_net.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_assign_to_supply_net.v
+++ b/test_regress/t/t_strength_assign_to_supply_net.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   supply1 a;
+   assign (strong0, strong1) a = 0;
+
+   always begin
+      if (a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_assign_z.pl
+++ b/test_regress/t/t_strength_assign_z.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_assign_z.v
+++ b/test_regress/t/t_strength_assign_z.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire (supply0, supply1) a = 'z;
+   wire (weak0, weak1) a = '1;
+
+   always begin
+      if (a === 1'b1) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_bufif1.out
+++ b/test_regress/t/t_strength_bufif1.out
@@ -1,0 +1,5 @@
+%Error-UNSUPPORTED: t/t_strength_bufif1.v:9:11: Unsupported: Strength specifier on this gate type
+    9 |    bufif1 (strong0, strong1) (a, 1'b1, 1'b1);
+      |           ^
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_strength_bufif1.pl
+++ b/test_regress/t/t_strength_bufif1.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_bufif1.v
+++ b/test_regress/t/t_strength_bufif1.v
@@ -1,0 +1,17 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire a;
+   bufif1 (strong0, strong1) (a, 1'b1, 1'b1);
+
+   always begin
+      if (a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_highz.out
+++ b/test_regress/t/t_strength_highz.out
@@ -1,0 +1,5 @@
+%Error-UNSUPPORTED: t/t_strength_highz.v:8:17: Unsupported: highz strength
+    8 |    wire (weak0, highz1) a = 1;
+      |                 ^~~~~~
+                    ... For error description see https://verilator.org/warn/UNSUPPORTED?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_strength_highz.pl
+++ b/test_regress/t/t_strength_highz.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+lint(
+    fails => $Self->{vlt_all},
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_highz.v
+++ b/test_regress/t/t_strength_highz.v
@@ -1,0 +1,16 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire (weak0, highz1) a = 1;
+
+   always begin
+      if (a === 1'bz) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule

--- a/test_regress/t/t_strength_strong1_strong1_bad.out
+++ b/test_regress/t/t_strength_strong1_strong1_bad.out
@@ -1,0 +1,4 @@
+%Error: t/t_strength_strong1_strong1_bad.v:8:19: syntax error, unexpected strong1
+    8 |    wire (strong1, strong1) a = 1;
+      |                   ^~~~~~~
+%Error: Exiting due to

--- a/test_regress/t/t_strength_strong1_strong1_bad.pl
+++ b/test_regress/t/t_strength_strong1_strong1_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_strength_strong1_strong1_bad.v
+++ b/test_regress/t/t_strength_strong1_strong1_bad.v
@@ -1,0 +1,13 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire (strong1, strong1) a = 1;
+   initial begin
+      $stop;
+   end
+
+endmodule

--- a/test_regress/t/t_var_sc_bv.cpp
+++ b/test_regress/t/t_var_sc_bv.cpp
@@ -1,0 +1,220 @@
+// -*- mode: C++; c-file-style: "cc-mode" -*-
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2022 by Wilson Snyder.
+// SPDX-License-Identifier: CC0-1.0
+
+#include VM_PREFIX_INCLUDE
+
+VM_PREFIX* tb = nullptr;
+bool pass = true;
+
+double sc_time_stamp() { return 0; }
+
+void compare_signals(const sc_signal<sc_bv<256>>& ls, const sc_signal<sc_bv<256>>& rs) {
+    if (ls.read() != rs.read()) {
+        pass &= false;
+        VL_PRINTF("%%Error: Data missmatch in signals %s and %s\n", ls.name(), rs.name());
+    }
+}
+
+void compareWls(int obits, WDataInP const lwp, WDataInP const rwp) {
+    const int words = VL_WORDS_I(obits);
+    bool same = true;
+
+    for (int i = 0; (i < (words - 1)); ++i) {
+        if (lwp[i] != rwp[i]) { same = false; }
+    }
+    if ((lwp[words - 1] & VL_MASK_E(obits)) != (rwp[words - 1] & VL_MASK_E(obits))) {
+        same = false;
+    }
+
+    if (!same) {
+        pass &= false;
+        VL_PRINTF("%%Error: There is a difference in VlWide variable %d bits wide\n", obits);
+    }
+}
+
+// old macro which is correct but has MT issue with range
+#define VL_ASSIGN_SBW_MT_ISSUE(obits, svar, rwp) \
+    { \
+        sc_biguint<(obits)> _butemp; \
+        for (int i = 0; i < VL_WORDS_I(obits); ++i) { \
+            int msb = ((i + 1) * VL_IDATASIZE) - 1; \
+            msb = (msb >= (obits)) ? ((obits)-1) : msb; \
+            _butemp.range(msb, i* VL_IDATASIZE) = (rwp)[i]; \
+        } \
+        (svar).write(_butemp); \
+    }
+
+#ifdef SYSTEMC_VERSION
+int sc_main(int, char**)
+#else
+int main()
+#endif
+{
+    Verilated::debug(0);
+    tb = new VM_PREFIX("tb");
+
+    VlWide<8> /*255:0*/ input_var;
+    VlWide<8> /*255:0*/ out_var;
+
+    // msb is always set to F not to be false positive on checking equality
+    input_var.m_storage[0] = 0xF2341234;
+    input_var.m_storage[1] = 0xFEADBEEF;
+    input_var.m_storage[2] = 0xF5A5A5A5;
+    input_var.m_storage[3] = 0xF1B2C3D4;
+    input_var.m_storage[4] = 0xFFFFFFFF;
+    input_var.m_storage[5] = 0xFAAABBBB;
+    input_var.m_storage[6] = 0xF000AAAA;
+    input_var.m_storage[7] = 0xF0101010;
+
+#ifdef SYSTEMC_VERSION
+    // clang-format off
+    sc_signal<sc_bv<256>> SC_NAMED(i_29_s), SC_NAMED(i_29_old_s), SC_NAMED(o_29_s), SC_NAMED(o_29_old_s),
+                          SC_NAMED(i_30_s), SC_NAMED(i_30_old_s), SC_NAMED(o_30_s), SC_NAMED(o_30_old_s),
+                          SC_NAMED(i_31_s), SC_NAMED(i_31_old_s), SC_NAMED(o_31_s), SC_NAMED(o_31_old_s),
+                          SC_NAMED(i_32_s), SC_NAMED(i_32_old_s), SC_NAMED(o_32_s), SC_NAMED(o_32_old_s),
+                          SC_NAMED(i_59_s), SC_NAMED(i_59_old_s), SC_NAMED(o_59_s), SC_NAMED(o_59_old_s),
+                          SC_NAMED(i_60_s), SC_NAMED(i_60_old_s), SC_NAMED(o_60_s), SC_NAMED(o_60_old_s),
+                          SC_NAMED(i_62_s), SC_NAMED(i_62_old_s), SC_NAMED(o_62_s), SC_NAMED(o_62_old_s),
+                          SC_NAMED(i_64_s), SC_NAMED(i_64_old_s), SC_NAMED(o_64_s), SC_NAMED(o_64_old_s),
+                          SC_NAMED(i_119_s), SC_NAMED(i_119_old_s), SC_NAMED(o_119_s), SC_NAMED(o_119_old_s),
+                          SC_NAMED(i_120_s), SC_NAMED(i_120_old_s), SC_NAMED(o_120_s), SC_NAMED(o_120_old_s),
+                          SC_NAMED(i_121_s), SC_NAMED(i_121_old_s), SC_NAMED(o_121_s), SC_NAMED(o_121_old_s),
+                          SC_NAMED(i_127_s), SC_NAMED(i_127_old_s), SC_NAMED(o_127_s), SC_NAMED(o_127_old_s),
+                          SC_NAMED(i_128_s), SC_NAMED(i_128_old_s), SC_NAMED(o_128_s), SC_NAMED(o_128_old_s),
+                          SC_NAMED(i_255_s), SC_NAMED(i_255_old_s), SC_NAMED(o_255_s), SC_NAMED(o_255_old_s),
+                          SC_NAMED(i_256_s), SC_NAMED(i_256_old_s), SC_NAMED(o_256_s), SC_NAMED(o_256_old_s);
+
+
+    tb->i_29(i_29_s); tb->i_29_old(i_29_old_s); tb->o_29(o_29_s); tb->o_29_old(o_29_old_s);
+    tb->i_30(i_30_s); tb->i_30_old(i_30_old_s); tb->o_30(o_30_s); tb->o_30_old(o_30_old_s);
+    tb->i_31(i_31_s); tb->i_31_old(i_31_old_s); tb->o_31(o_31_s); tb->o_31_old(o_31_old_s);
+    tb->i_32(i_32_s); tb->i_32_old(i_32_old_s); tb->o_32(o_32_s); tb->o_32_old(o_32_old_s);
+    tb->i_59(i_59_s); tb->i_59_old(i_59_old_s); tb->o_59(o_59_s); tb->o_59_old(o_59_old_s);
+    tb->i_60(i_60_s); tb->i_60_old(i_60_old_s); tb->o_60(o_60_s); tb->o_60_old(o_60_old_s);
+    tb->i_62(i_62_s); tb->i_62_old(i_62_old_s); tb->o_62(o_62_s); tb->o_62_old(o_62_old_s);
+    tb->i_64(i_64_s); tb->i_64_old(i_64_old_s); tb->o_64(o_64_s); tb->o_64_old(o_64_old_s);
+    tb->i_119(i_119_s); tb->i_119_old(i_119_old_s); tb->o_119(o_119_s); tb->o_119_old(o_119_old_s);
+    tb->i_120(i_120_s); tb->i_120_old(i_120_old_s); tb->o_120(o_120_s); tb->o_120_old(o_120_old_s);
+    tb->i_121(i_121_s); tb->i_121_old(i_121_old_s); tb->o_121(o_121_s); tb->o_121_old(o_121_old_s);
+    tb->i_127(i_127_s); tb->i_127_old(i_127_old_s); tb->o_127(o_127_s); tb->o_127_old(o_127_old_s);
+    tb->i_128(i_128_s); tb->i_128_old(i_128_old_s); tb->o_128(o_128_s); tb->o_128_old(o_128_old_s);
+    tb->i_255(i_255_s); tb->i_255_old(i_255_old_s); tb->o_255(o_255_s); tb->o_255_old(o_255_old_s);
+    tb->i_256(i_256_s); tb->i_256_old(i_256_old_s); tb->o_256(o_256_s); tb->o_256_old(o_256_old_s);
+
+    // clang-format on
+
+#endif
+
+// clang-format off
+#ifdef SYSTEMC_VERSION
+    sc_start(1, SC_NS);
+#else
+    tb->eval();
+#endif
+    // This testcase is testing multi-thread safe VL_ASSIGN_SBW and VL_ASSIGN_WSB macros.
+    // Testbench is assigning different number of bits from VlWide input_var variable to different inputs.
+    // Values around multiple of 30 (i.e. BITS_PER_DIGIT defined in SystemC sc_nbdefs.h) are tested with the special care, since
+    // it is the value by which the data_ptr of sc_biguint underlying data type is increased by (and not expected 32, as width of uint32_t).
+    // Correctness of the output is compared against the 'old' macro, which is correct but has multi-threaded issue since it's using range function.
+    // Second part is testing VL_ASSIGN_WSB in a reverse way, it is reading signals from the previous test,
+    // and comparing the output with (fraction) of VlWide input_var variable.
+
+    // clang-format on
+    VL_ASSIGN_SBW(29, i_29_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(29, i_29_old_s, input_var);
+    VL_ASSIGN_SBW(30, i_30_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(30, i_30_old_s, input_var);
+    VL_ASSIGN_SBW(31, i_31_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(31, i_31_old_s, input_var);
+    VL_ASSIGN_SBW(32, i_32_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(32, i_32_old_s, input_var);
+    VL_ASSIGN_SBW(59, i_59_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(59, i_59_old_s, input_var);
+    VL_ASSIGN_SBW(60, i_60_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(60, i_60_old_s, input_var);
+    VL_ASSIGN_SBW(62, i_62_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(62, i_62_old_s, input_var);
+    VL_ASSIGN_SBW(64, i_64_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(64, i_64_old_s, input_var);
+    VL_ASSIGN_SBW(119, i_119_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(119, i_119_old_s, input_var);
+    VL_ASSIGN_SBW(120, i_120_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(120, i_120_old_s, input_var);
+    VL_ASSIGN_SBW(121, i_121_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(121, i_121_old_s, input_var);
+    VL_ASSIGN_SBW(127, i_127_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(127, i_127_old_s, input_var);
+    VL_ASSIGN_SBW(128, i_128_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(128, i_128_old_s, input_var);
+    VL_ASSIGN_SBW(255, i_255_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(255, i_255_old_s, input_var);
+    VL_ASSIGN_SBW(256, i_256_s, input_var);
+    VL_ASSIGN_SBW_MT_ISSUE(256, i_256_old_s, input_var);
+
+#ifdef SYSTEMC_VERSION
+    sc_start(1, SC_NS);
+#else
+    tb->eval();
+#endif
+    compare_signals(o_29_s, o_29_old_s);
+    compare_signals(o_30_s, o_30_old_s);
+    compare_signals(o_31_s, o_31_old_s);
+    compare_signals(o_32_s, o_32_old_s);
+    compare_signals(o_59_s, o_59_old_s);
+    compare_signals(o_60_s, o_60_old_s);
+    compare_signals(o_62_s, o_62_old_s);
+    compare_signals(o_64_s, o_64_old_s);
+    compare_signals(o_119_s, o_119_old_s);
+    compare_signals(o_120_s, o_120_old_s);
+    compare_signals(o_121_s, o_121_old_s);
+    compare_signals(o_127_s, o_127_old_s);
+    compare_signals(o_128_s, o_128_old_s);
+    compare_signals(o_255_s, o_255_old_s);
+    compare_signals(o_256_s, o_256_old_s);
+
+    ////////////////////////////////
+
+    VL_ASSIGN_WSB(29, out_var, o_29_s);
+    compareWls(29, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(30, out_var, o_30_s);
+    compareWls(30, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(31, out_var, o_31_s);
+    compareWls(31, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(32, out_var, o_32_s);
+    compareWls(32, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(59, out_var, o_59_s);
+    compareWls(59, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(60, out_var, o_60_s);
+    compareWls(60, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(62, out_var, o_62_s);
+    compareWls(62, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(64, out_var, o_64_s);
+    compareWls(64, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(119, out_var, o_119_s);
+    compareWls(119, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(120, out_var, o_120_s);
+    compareWls(120, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(121, out_var, o_121_s);
+    compareWls(121, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(127, out_var, o_127_s);
+    compareWls(127, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(128, out_var, o_128_s);
+    compareWls(128, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(255, out_var, o_255_s);
+    compareWls(255, input_var.data(), out_var.data());
+    VL_ASSIGN_WSB(256, out_var, o_256_s);
+    compareWls(256, input_var.data(), out_var.data());
+
+    tb->final();
+    VL_DO_DANGLING(delete tb, tb);
+
+    if (pass) {
+        VL_PRINTF("*-* All Finished *-*\n");
+    } else {
+        vl_fatal(__FILE__, __LINE__, "top", "Unexpected results from test\n");
+    }
+    return 0;
+}

--- a/test_regress/t/t_var_sc_bv.pl
+++ b/test_regress/t/t_var_sc_bv.pl
@@ -1,0 +1,24 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2003-2009 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt_all => 1);
+
+compile(
+    make_top_shell => 0,
+    make_main => 0,
+    verilator_flags2 => ["--exe $Self->{t_dir}/t_var_sc_bv.cpp --sc -fno-inline"],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_var_sc_bv.v
+++ b/test_regress/t/t_var_sc_bv.v
@@ -1,0 +1,246 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed into the Public Domain, for any use,
+// without warranty, 2008 by Lane Brooks.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+   // Outputs
+   o_29,o_29_old,
+   o_30,o_30_old,
+   o_31,o_31_old,
+   o_32,o_32_old,
+   o_59,o_59_old,
+   o_60,o_60_old,
+   o_62,o_62_old,
+   o_64,o_64_old,
+   o_119,o_119_old,
+   o_120,o_120_old,
+   o_121,o_121_old,
+   o_127,o_127_old,
+   o_128,o_128_old,
+   o_255,o_255_old,
+   o_256,o_256_old,
+   // Inputs
+   i_29,i_29_old,
+   i_30,i_30_old,
+   i_31,i_31_old,
+   i_32,i_32_old,
+   i_59,i_59_old,
+   i_60,i_60_old,
+   i_62,i_62_old,
+   i_64,i_64_old,
+   i_119,i_119_old,
+   i_120,i_120_old,
+   i_121,i_121_old,
+   i_127,i_127_old,
+   i_128,i_128_old,
+   i_255,i_255_old,
+   i_256,i_256_old
+   );
+   input [255:0]        i_29;
+   output wire [255:0]  o_29;
+   input [255:0]        i_29_old;
+   output wire [255:0]  o_29_old;
+   input [255:0]        i_30;
+   output wire [255:0]  o_30;
+   input [255:0]        i_30_old;
+   output wire [255:0]  o_30_old;
+   input [255:0]        i_31;
+   output wire [255:0]  o_31;
+   input [255:0]        i_31_old;
+   output wire [255:0]  o_31_old;
+   input [255:0]        i_32;
+   output wire [255:0]  o_32;
+   input [255:0]        i_32_old;
+   output wire [255:0]  o_32_old;
+   input [255:0]        i_59;
+   output wire [255:0]  o_59;
+   input [255:0]        i_59_old;
+   output wire [255:0]  o_59_old;
+   input [255:0]        i_60;
+   output wire [255:0]  o_60;
+   input [255:0]        i_60_old;
+   output wire [255:0]  o_60_old;
+   input [255:0]        i_62;
+   output wire [255:0]  o_62;
+   input [255:0]        i_62_old;
+   output wire [255:0]  o_62_old;
+   input [255:0]        i_64;
+   output wire [255:0]  o_64;
+   input [255:0]        i_64_old;
+   output wire [255:0]  o_64_old;
+   input [255:0]       i_119;
+   output wire [255:0] o_119;
+   input [255:0]       i_119_old;
+   output wire [255:0] o_119_old;
+   input [255:0]       i_120;
+   output wire [255:0] o_120;
+   input [255:0]       i_120_old;
+   output wire [255:0] o_120_old;
+   input [255:0]       i_121;
+   output wire [255:0] o_121;
+   input [255:0]       i_121_old;
+   output wire [255:0] o_121_old;
+   input [255:0]       i_127;
+   output wire [255:0] o_127;
+   input [255:0]       i_127_old;
+   output wire [255:0] o_127_old;
+   input [255:0]       i_128;
+   output wire [255:0] o_128;
+   input [255:0]       i_128_old;
+   output wire [255:0] o_128_old;
+   input [255:0]       i_255;
+   output wire [255:0] o_255;
+   input [255:0]       i_255_old;
+   output wire [255:0] o_255_old;
+   input [255:0]       i_256;
+   output wire [255:0] o_256;
+   input [255:0]       i_256_old;
+   output wire [255:0] o_256_old;
+
+   sub sub (.*);
+endmodule
+
+module sub (/*AUTOARG*/
+   // Outputs
+   o_29,o_29_old,
+   o_30,o_30_old,
+   o_31,o_31_old,
+   o_32,o_32_old,
+   o_59,o_59_old,
+   o_60,o_60_old,
+   o_62,o_62_old,
+   o_64,o_64_old,
+   o_119,o_119_old,
+   o_120,o_120_old,
+   o_121,o_121_old,
+   o_127,o_127_old,
+   o_128,o_128_old,
+   o_255,o_255_old,
+   o_256,o_256_old,
+   // Inputs
+   i_29,i_29_old,
+   i_30,i_30_old,
+   i_31,i_31_old,
+   i_32,i_32_old,
+   i_59,i_59_old,
+   i_60,i_60_old,
+   i_62,i_62_old,
+   i_64,i_64_old,
+   i_119,i_119_old,
+   i_120,i_120_old,
+   i_121,i_121_old,
+   i_127,i_127_old,
+   i_128,i_128_old,
+   i_255,i_255_old,
+   i_256,i_256_old
+   );
+
+   input [255:0]        i_29;
+   output wire [255:0]  o_29;
+   input [255:0]        i_29_old;
+   output wire [255:0]  o_29_old;
+   input [255:0]        i_30;
+   output wire [255:0]  o_30;
+   input [255:0]        i_30_old;
+   output wire [255:0]  o_30_old;
+   input [255:0]        i_31;
+   output wire [255:0]  o_31;
+   input [255:0]        i_31_old;
+   output wire [255:0]  o_31_old;
+   input [255:0]        i_32;
+   output wire [255:0]  o_32;
+   input [255:0]        i_32_old;
+   output wire [255:0]  o_32_old;
+   input [255:0]        i_59;
+   output wire [255:0]  o_59;
+   input [255:0]        i_59_old;
+   output wire [255:0]  o_59_old;
+   input [255:0]        i_60;
+   output wire [255:0]  o_60;
+   input [255:0]        i_60_old;
+   output wire [255:0]  o_60_old;
+   input [255:0]        i_62;
+   output wire [255:0]  o_62;
+   input [255:0]        i_62_old;
+   output wire [255:0]  o_62_old;
+   input [255:0]        i_64;
+   output wire [255:0]  o_64;
+   input [255:0]        i_64_old;
+   output wire [255:0]  o_64_old;
+   input [255:0]       i_119;
+   output wire [255:0] o_119;
+   input [255:0]       i_119_old;
+   output wire [255:0] o_119_old;
+   input [255:0]       i_120;
+   output wire [255:0] o_120;
+   input [255:0]       i_120_old;
+   output wire [255:0] o_120_old;
+   input [255:0]       i_121;
+   output wire [255:0] o_121;
+   input [255:0]       i_121_old;
+   output wire [255:0] o_121_old;
+   input [255:0]       i_127;
+   output wire [255:0] o_127;
+   input [255:0]       i_127_old;
+   output wire [255:0] o_127_old;
+   input [255:0]       i_128;
+   output wire [255:0] o_128;
+   input [255:0]       i_128_old;
+   output wire [255:0] o_128_old;
+   input [255:0]       i_255;
+   output wire [255:0] o_255;
+   input [255:0]       i_255_old;
+   output wire [255:0] o_255_old;
+   input [255:0]       i_256;
+   output wire [255:0] o_256;
+   input [255:0]       i_256_old;
+   output wire [255:0] o_256_old;
+
+   assign o_29 = i_29;
+   assign o_29_old = i_29_old;
+
+   assign o_30 = i_30;
+   assign o_30_old = i_30_old;
+
+   assign o_31 = i_31;
+   assign o_31_old = i_31_old;
+
+   assign o_32 = i_32;
+   assign o_32_old = i_32_old;
+
+   assign o_59 = i_59;
+   assign o_59_old = i_59_old;
+
+   assign o_60 = i_60;
+   assign o_60_old = i_60_old;
+
+   assign o_62 = i_62;
+   assign o_62_old = i_62_old;
+
+   assign o_64 = i_64;
+   assign o_64_old = i_64_old;
+
+   assign o_119 = i_119;
+   assign o_119_old = i_119_old;
+
+   assign o_120 = i_120;
+   assign o_120_old = i_120_old;
+
+   assign o_121 = i_121;
+   assign o_121_old = i_121_old;
+
+   assign o_127 = i_127;
+   assign o_127_old = i_127_old;
+
+   assign o_128 = i_128;
+   assign o_128_old = i_128_old;
+
+   assign o_255 = i_255;
+   assign o_255_old = i_255_old;
+
+   assign o_256 = i_256;
+   assign o_256_old = i_256_old;
+
+endmodule

--- a/test_regress/t/t_weak_nor_strong_assign.pl
+++ b/test_regress/t/t_weak_nor_strong_assign.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_weak_nor_strong_assign.v
+++ b/test_regress/t/t_weak_nor_strong_assign.v
@@ -1,0 +1,18 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/);
+   wire a;
+   nor (pull0, weak1) n1(a, 0, 0);
+   assign (strong0, weak1) a = 0;
+
+   always begin
+      if (!a) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+   end
+endmodule


### PR DESCRIPTION
It is another approach to handle signal strength. Previous was there: https://github.com/antmicro/verilator-1/pull/12 and parsing phase is just copied.
Here I add the handling of case when the strongest driver is a constant. I just find the strongest assignment with constant on RHS and then just remove all weaker or equally strong assignments.

To be more formal:
I find the assignment of value 0 (size may be greater than 1) that has greatest strength (the one corresponding to 0) of all other assignments of 0.
Then I do the same for value `'1` and strength corresponding to value 1.
Then I find greater of these two strengths. If they are equal I take the one that corresponds to 1.
Then I remove all assignments that have strengths weaker or equal to the one I found.
So I remove all other assignments of constants on RHS and also all assignment that have both strengths non-greater that the one I found, because they are weaker not matter what is on RHS.

All assignments that are stronger than the one with strongest constant I leave as they are.

There is a possible problem with equally strong assignments, because multiple assignments with the same strength, but different values should result in `x` value, but these values are unsupported.

In some cases the first AstAssignW of some net was changed to AstAssign and put into `initial` block and the value of RHS is put into `valuep()`.
I delayed this step to be happening after V3Tristate phase. I did this, because the value of the first assignment may be overwritten by some stronger assignment and also change of assignment type made the handling more complicated, because strengths can only be specified for continuous assignments. 