### PR TITLE
Add jumps support in do while loops

### DIFF
--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -2209,7 +2209,7 @@ AstNode* AstNode::addNext<AstNode, AstNode>(AstNode* nodep, AstNode* newp);
 AstNode* AstNode::addNext(AstNode* newp) { return addNext(this, newp); }
 void AstNode::addPrev(AstNode* newp) {
     replaceWith(newp);
-    newp->addNext(this);
+    newp->addNextHere(this);
 }
 
 // Specialisations of privateTypeTest

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -2725,6 +2725,25 @@ public:
     // * = Add a newline for $display
     bool addNewline() const { return displayType().addNewline(); }
 };
+class AstDoWhile final : public AstNodeStmt {
+    // @astgen op1 := precondsp : List[AstNode]
+    // @astgen op2 := condp : AstNode
+    // @astgen op3 := stmtsp : List[AstNode]
+    // @astgen op4 := incsp : List[AstNode]
+public:
+    AstDoWhile(FileLine* fl, AstNode* condp, AstNode* stmtsp = nullptr, AstNode* incsp = nullptr)
+        : ASTGEN_SUPER_DoWhile(fl) {
+        this->condp(condp);
+        this->addStmtsp(stmtsp);
+        this->addIncsp(incsp);
+    }
+    ASTGEN_MEMBERS_AstDoWhile;
+    bool isGateOptimizable() const override { return false; }
+    int instrCount() const override { return INSTR_COUNT_BRANCH; }
+    bool same(const AstNode* /*samep*/) const override { return true; }
+    // Stop statement searchback here
+    bool isFirstInMyListOfStatements(AstNode* n) const override { return n == stmtsp(); }
+};
 class AstDumpCtl final : public AstNodeStmt {
     // $dumpon etc
     // Parents: expr

--- a/src/verilog.y
+++ b/src/verilog.y
@@ -3324,11 +3324,7 @@ statement_item<nodep>:          // IEEE: statement_item
         |       yWHILE '(' expr ')' stmtBlock           { $$ = new AstWhile{$1, $3, $5}; }
         //                      // for's first ';' is in for_initialization
         |       statementFor                            { $$ = $1; }
-        |       yDO stmtBlock yWHILE '(' expr ')' ';'   { if ($2) {
-                                                             $$ = $2->cloneTree(true);
-                                                             $$->addNext(new AstWhile($1,$5,$2));
-                                                          }
-                                                          else $$ = new AstWhile($1,$5); }
+        |       yDO stmtBlock yWHILE '(' expr ')' ';'   { $$ = new AstDoWhile{$1, $5, $2}; }
         //                      // IEEE says array_identifier here, but dotted accepted in VMM and 1800-2009
         |       yFOREACH '(' idClassSelForeach ')' stmtBlock    { $$ = new AstForeach($1, $3, $5); }
         //

--- a/test_regress/t/t_continue_do_while_bad.out
+++ b/test_regress/t/t_continue_do_while_bad.out
@@ -1,0 +1,6 @@
+%Warning-INFINITELOOP: t/t_continue_do_while_bad.v:14:7: Infinite loop (condition always true)
+   14 |       do begin
+      |       ^~
+                       ... For warning description see https://verilator.org/warn/INFINITELOOP?v=latest
+                       ... Use "/* verilator lint_off INFINITELOOP */" and lint_on around source to disable this message.
+%Error: Exiting due to

--- a/test_regress/t/t_continue_do_while_bad.pl
+++ b/test_regress/t/t_continue_do_while_bad.pl
@@ -1,0 +1,20 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(vlt => 1);
+
+compile(
+    expect_filename=>$Self->{golden_filename},
+    verilator_flags2=> ['--assert'],
+    fails => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_continue_do_while_bad.v
+++ b/test_regress/t/t_continue_do_while_bad.v
@@ -1,0 +1,24 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+
+   function void infinite_loop;
+      do begin
+         continue;
+      end
+      while (1);
+   endfunction
+
+   always @(posedge clk) begin
+      infinite_loop();
+      $stop;
+   end
+endmodule

--- a/test_regress/t/t_jumps_do_while.pl
+++ b/test_regress/t/t_jumps_do_while.pl
@@ -1,0 +1,22 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2022 by Antmicro Ltd. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    verilator_flags2 => ['--assert'],
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_jumps_do_while.v
+++ b/test_regress/t/t_jumps_do_while.v
@@ -1,0 +1,173 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2022 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+module t (/*AUTOARG*/
+      clk
+   );
+
+   input clk;
+
+   function bit test_1;
+      int iterations = 0;
+      do begin
+         iterations++;
+         break;
+      end
+      while (1);
+      return iterations == 1;
+   endfunction
+
+   function bit test_2;
+      int iterations = 0;
+      do begin
+         break;
+         iterations++;
+      end
+      while (1);
+      return iterations == 0;
+   endfunction
+
+   function bit test_3;
+      do
+         break;
+      while (1);
+      return 1'b1;
+   endfunction
+
+   function bit test_4;
+      int incr = 0;
+      do begin
+         incr++;
+         break;
+         incr++;
+      end
+      while (1);
+      return incr == 1;
+   endfunction
+
+   function bit test_5;
+      int incr = 0;
+      do begin
+         do
+            incr++;
+         while (incr < 9);
+         incr++;
+         break;
+         incr++;
+      end
+      while (1);
+      return incr == 10;
+   endfunction
+
+   function bit test_6;
+      int incr = 0;
+      do begin
+         do begin
+            incr += 1;
+            incr += 2;
+         end
+         while (incr < 9);
+         incr++;
+         break;
+         incr++;
+      end
+      while (1);
+      return incr == 10;
+   endfunction
+
+   function bit test_7;
+      int incr = 0;
+      do begin
+         do begin
+            incr += 1;
+            break;
+            incr += 2;
+         end
+         while (incr < 9);
+         incr++;
+         break;
+         incr++;
+      end
+      while (1);
+      return incr == 2;
+   endfunction
+
+   function bit test_8;
+      int incr = 0;
+      do begin
+         incr++;
+         continue;
+         incr++;
+      end
+      while (0);
+      return incr == 1;
+   endfunction
+
+   function bit test_9;
+      int incr = 0;
+      do begin
+         incr++;
+         continue;
+         incr++;
+      end
+      while (incr < 5);
+      return incr == 5;
+   endfunction
+
+   function bit test_10;
+      do begin
+         continue;
+      end
+      while (0);
+      return 1'b1;
+   endfunction
+
+   function bit test_11;
+      int incr = 0;
+      do begin
+         do
+            incr++;
+         while (0);
+         incr++;
+         continue;
+         incr++;
+      end
+      while (incr < 11);
+      return incr == 12;
+   endfunction
+
+   function bit test_12;
+      int incr = 0;
+      do begin
+         do begin
+            incr++;
+            continue;
+            incr++;
+         end
+         while (0);
+         incr++;
+         continue;
+         incr++;
+      end
+      while (incr < 11);
+      return incr == 12;
+   endfunction
+
+   always @(posedge clk) begin
+      bit [11:0] results = {test_1(), test_2(), test_3(), test_4(), test_5(),
+                            test_6(), test_7(), test_8(), test_9(), test_10(),
+                            test_11(), test_12()};
+
+      if (results == '1) begin
+         $write("*-* All Finished *-*\n");
+         $finish;
+      end
+      else begin
+         $write("Results: %b\n", results);
+         $stop;
+      end
+   end
+endmodule


### PR DESCRIPTION
Previously `do while` loops were parsed as normal `while` loops with a copy of body inserted before a loop. If there was `break` statement inside a body, the error was thrown: `break isn't underneath a loop`. Similar situation was with `continue` statement. So I created separate node for that kind of loop and I added converting it into `while` loop in V3LinkJump, when `break` and `continue` statements are handled.

Now I explain the change in `addPrev` implementation. Without it, the statement
`whilep->addPrev(bodyp->cloneTree(false));`
moved `whilep` node at the end of statements in a block.
Here is an example:
```systemverilog
      while (1) begin
         do
            ++incr;
         while (incr < 9);
         incr++;
         break;
```
In the example, the inner `while` is put after postincrementation and break stataments.
Here is the AST (without the change, PREADD and POSTADD subtrees are shortened):
```
    1:2:3: JUMPBLOCK 0x555556d20000 <e122#> {c4ah}
    1:2:3:1: WHILE 0x555556d16370 <e120#> {c4ah}
    1:2:3:1:2: CONST 0x555556cc2300 <e66> {c4ao} @dt=0x555556cd61a0@(G/swu32/1)  ?32?sh1
    1:2:3:1:3: BEGIN 0x555556cee380 <e25> {c4ar} [UNNAMED]
    1:2:3:1:3:1: PREADD 0x555556d16630 <e116#> {c6an} @dt=0@
    1:2:3:1:3:1: POSTADD 0x555556d16210 <e62> {c8ao} @dt=0@
    1:2:3:1:3:1: JUMPGO 0x555556d20180 <e124#> {c9ak} -> JUMPLABEL 0x555556d200c0 <e119#> {c4ah} -> JUMPBLOCK 0x555556d20000 <e122#> {c4ah}
    1:2:3:1:3:1: WHILE 0x555556d16580 <e117#> {c5ak}
    1:2:3:1:3:1:2: LT 0x555556d160b0 <e110#> {c7aw} @dt=0x555556cd6820@(G/w1)
    1:2:3:1:3:1:2:1: VARREF 0x555556cd0360 <e80#> {c7ar} @dt=0@  incr [RV] <- VAR 0x555556cce180 <e16> {c3al} @dt=0@  incr [FUNC] [VAUTOM]  VAR
    1:2:3:1:3:1:2:2: CONST 0x555556cc2500 <e44> {c7ay} @dt=0x555556cd6750@(G/swu32/4)  ?32?sh9
    1:2:3:1:3:1:3: PREADD 0x555556d16000 <e108#> {c6an} @dt=0@
    1:2:3:2: JUMPLABEL 0x555556d200c0 <e119#> {c4ah} -> JUMPBLOCK 0x555556d20000 <e122#> {c4ah}
```
And the one after the change (correct one):
```
    1:2:3: JUMPBLOCK 0x555556d20000 <e122#> {c4ah}
    1:2:3:1: WHILE 0x555556d16370 <e120#> {c4ah}
    1:2:3:1:2: CONST 0x555556cc2300 <e66> {c4ao} @dt=0x555556cd61a0@(G/swu32/1)  ?32?sh1
    1:2:3:1:3: BEGIN 0x555556cee380 <e25> {c4ar} [UNNAMED]
    1:2:3:1:3:1: PREADD 0x555556d16630 <e116#> {c6an} @dt=0@
    1:2:3:1:3:1: WHILE 0x555556d16580 <e117#> {c5ak}
    1:2:3:1:3:1:2: LT 0x555556d160b0 <e110#> {c7aw} @dt=0x555556cd6820@(G/w1)
    1:2:3:1:3:1:2:1: VARREF 0x555556cd0360 <e80#> {c7ar} @dt=0@  incr [RV] <- VAR 0x555556cce180 <e16> {c3al} @dt=0@  incr [FUNC] [VAUTOM]  VAR
    1:2:3:1:3:1:2:2: CONST 0x555556cc2500 <e44> {c7ay} @dt=0x555556cd6750@(G/swu32/4)  ?32?sh9
    1:2:3:1:3:1:3: PREADD 0x555556d16000 <e108#> {c6an} @dt=0@
    1:2:3:1:3:1: POSTADD 0x555556d16210 <e62> {c8ao} @dt=0@
    1:2:3:1:3:1: JUMPGO 0x555556d20180 <e124#> {c9ak} -> JUMPLABEL 0x555556d200c0 <e119#> {c4ah} -> JUMPBLOCK 0x555556d20000 <e122#> {c4ah}
    1:2:3:2: JUMPLABEL 0x555556d200c0 <e119#> {c4ah} -> JUMPBLOCK 0x555556d20000 <e122#> {c4ah}
```
So old `addPrev` implementation breaks the order of other nodes, which sometimes may cause a different behavior.