### PR TITLE
Fix namespace resolution

### DIFF
--- a/src/V3ParseImp.cpp
+++ b/src/V3ParseImp.cpp
@@ -496,7 +496,7 @@ void V3ParseImp::tokenPipelineSym() {
         if (const VSymEnt* const look_underp = V3ParseImp::parsep()->symp()->nextId()) {
             UINFO(7, "   tokenPipelineSym: next id lookup forced under " << look_underp << endl);
             // if (debug() >= 7) V3ParseImp::parsep()->symp()->dumpSelf(cout, " -symtree: ");
-            foundp = look_underp->findIdFallback(*(yylval.strp));
+            foundp = look_underp->findIdFlat(*(yylval.strp));
             // "consume" it.  Must set again if want another token under temp scope
             V3ParseImp::parsep()->symp()->nextId(nullptr);
         } else {

--- a/test_regress/t/t_pkg_identifier_bad.out
+++ b/test_regress/t/t_pkg_identifier_bad.out
@@ -1,0 +1,5 @@
+%Error-PKGNODECL: t/t_pkg_identifier_bad.v:15:20: Package/class 'bar' not found, and needs to be predeclared (IEEE 1800-2017 26.3)
+   15 |     int baz = foo::bar::baz;
+      |                    ^~~
+                  ... For error description see https://verilator.org/warn/PKGNODECL?v=latest
+%Error: Exiting due to

--- a/test_regress/t/t_pkg_identifier_bad.pl
+++ b/test_regress/t/t_pkg_identifier_bad.pl
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(linter => 1);
+
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_pkg_identifier_bad.v
+++ b/test_regress/t/t_pkg_identifier_bad.v
@@ -1,0 +1,16 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+package foo;
+endpackage
+
+package bar;
+    static int baz;
+endpackage
+
+module t;
+    int baz = foo::bar::baz;
+endmodule

--- a/test_regress/t/t_std_identifier_bad.pl
+++ b/test_regress/t/t_std_identifier_bad.pl
@@ -10,10 +10,10 @@ if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); di
 
 scenarios(linter => 1);
 
-#lint(
-#    fails => 1,
-#    expect_filename => $Self->{golden_filename},
-#    );
+lint(
+    fails => 1,
+    expect_filename => $Self->{golden_filename},
+    );
 
 lint(
     verilator_flags2 => ["-DTEST_DECLARE_STD"],


### PR DESCRIPTION
This fixes a previously reported problem with package identifiers.

The only functional change is that fallback search isn't used for references to symbols from other scopes.
The rationale behind it is that every scope should be able to access only its own parent scopes.

The PR brings back t_std_identifier_bad test and adds a similar test that uses more neutral package names.
