### PR TITLE
Fix struct redefinition

### DIFF
--- a/src/V3Class.cpp
+++ b/src/V3Class.cpp
@@ -183,7 +183,8 @@ private:
         // Give struct a pointer to its package and a final name
         dtypep->editCountInc();
         dtypep->classOrPackagep(m_classPackagep ? m_classPackagep : m_modp);
-        dtypep->name(m_names.get(dtypep->name() + (VN_IS(dtypep, UnionDType) ? "__union" : "__struct")));
+        dtypep->name(
+            m_names.get(dtypep->name() + (VN_IS(dtypep, UnionDType) ? "__union" : "__struct")));
 
         for (const AstMemberDType* itemp = dtypep->membersp(); itemp;
              itemp = VN_AS(itemp->nextp(), MemberDType)) {

--- a/src/V3Class.cpp
+++ b/src/V3Class.cpp
@@ -27,6 +27,7 @@
 
 #include "V3Ast.h"
 #include "V3Global.h"
+#include "V3UniqueNames.h"
 
 VL_DEFINE_DEBUG_FUNCTIONS;
 
@@ -41,6 +42,7 @@ private:
 
     // MEMBERS
     string m_prefix;  // String prefix to add to name based on hier
+    V3UniqueNames m_names;  // For unique naming of structs and unions
     AstNodeModule* m_modp = nullptr;  // Current module
     AstNodeModule* m_classPackagep = nullptr;  // Package moving into
     const AstScope* m_classScopep = nullptr;  // Package moving scopes into
@@ -181,8 +183,7 @@ private:
         // Give struct a pointer to its package and a final name
         dtypep->editCountInc();
         dtypep->classOrPackagep(m_classPackagep ? m_classPackagep : m_modp);
-        dtypep->name(dtypep->name() + (VN_IS(dtypep, UnionDType) ? "__union" : "__struct")
-                     + cvtToStr(dtypep->uniqueNum()));
+        dtypep->name(m_names.get(dtypep->name() + (VN_IS(dtypep, UnionDType) ? "__union" : "__struct")));
 
         for (const AstMemberDType* itemp = dtypep->membersp(); itemp;
              itemp = VN_AS(itemp->nextp(), MemberDType)) {

--- a/test_regress/t/t_unpacked_struct_redef.pl
+++ b/test_regress/t/t_unpacked_struct_redef.pl
@@ -1,0 +1,21 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2023 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_unpacked_struct_redef.v
+++ b/test_regress/t/t_unpacked_struct_redef.v
@@ -1,0 +1,26 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
+class Class#(parameter WIDTH);
+    typedef logic [WIDTH-1:0] word;
+    typedef struct {
+        word w;
+    } Struct;
+endclass
+
+module t;
+   Class#(1)::Struct s1;
+   Class#(1)::Struct s2;
+   Class#(2)::Struct s3;
+
+   initial begin
+      $display("%p", s1);
+      $display("%p", s2);
+      $display("%p", s3);
+      $write("*-* All Finished *-*\n");
+      $finish;
+   end
+endmodule


### PR DESCRIPTION
This fixes #4256 by changing the way names of unpacked structs are made unique.
