### PR TITLE
Fix state update for always processes

### DIFF
--- a/src/V3Timing.cpp
+++ b/src/V3Timing.cpp
@@ -592,6 +592,8 @@ private:
     }
     void visit(AstAlways* nodep) override {
         if (nodep->user1SetOnce()) return;
+        VL_RESTORER(m_procp);
+        m_procp = nodep;
         iterateChildren(nodep);
         if (!nodep->user2()) return;
         if (nodep->user2() == T_PROC) nodep->setNeedProcess();

--- a/test_regress/t/t_process_task.pl
+++ b/test_regress/t/t_process_task.pl
@@ -1,0 +1,23 @@
+#!/usr/bin/env perl
+if (!$::Driver) { use FindBin; exec("$FindBin::Bin/bootstrap.pl", @ARGV, $0); die; }
+# DESCRIPTION: Verilator: Verilog Test driver/expect definition
+#
+# Copyright 2020 by Wilson Snyder. This program is free software; you
+# can redistribute it and/or modify it under the terms of either the GNU
+# Lesser General Public License Version 3 or the Perl Artistic License
+# Version 2.0.
+# SPDX-License-Identifier: LGPL-3.0-only OR Artistic-2.0
+
+scenarios(simulator => 1);
+
+compile(
+    v_flags2 => ["--exe --main --timing"],
+    make_main => 0,
+    );
+
+execute(
+    check_finished => 1,
+    );
+
+ok(1);
+1;

--- a/test_regress/t/t_process_task.v
+++ b/test_regress/t/t_process_task.v
@@ -5,10 +5,10 @@ module t();
 
    always #1 clk = ~clk;
 
-   task kill_me_after_1ns(std::process proc);
+   task kill_me_after_1ns();
       fork
-         #1 proc.kill(); // kill proc after 1 step
-         #3 begin        // finish after the next clock cycle
+         #1 proc.kill();
+         #3 begin
             $write("*-* All Finished *-*\n");
             $finish;
          end
@@ -18,7 +18,7 @@ module t();
    always @(posedge clk) begin
       if (!b) begin
          proc = std::process::self();
-         kill_me_after_1ns(proc);
+         kill_me_after_1ns();
          b = 1;
       end else begin
          $stop;

--- a/test_regress/t/t_process_task.v
+++ b/test_regress/t/t_process_task.v
@@ -1,0 +1,27 @@
+module t();
+   std::process proc;
+   logic clk = 0;
+   logic b = 0;
+
+   always #1 clk = ~clk;
+
+   task kill_me_after_1ns(std::process proc);
+      fork
+         #1 proc.kill(); // kill proc after 1 step
+         #3 begin        // finish after the next clock cycle
+            $write("*-* All Finished *-*\n");
+            $finish;
+         end
+      join_none
+   endtask
+
+   always @(posedge clk) begin
+      if (!b) begin
+         proc = std::process::self();
+         kill_me_after_1ns(proc);
+         b = 1;
+      end else begin
+         $stop;
+      end
+   end
+endmodule

--- a/test_regress/t/t_process_task.v
+++ b/test_regress/t/t_process_task.v
@@ -1,3 +1,9 @@
+// DESCRIPTION: Verilator: Verilog Test module
+//
+// This file ONLY is placed under the Creative Commons Public Domain, for
+// any use, without warranty, 2023 by Antmicro Ltd.
+// SPDX-License-Identifier: CC0-1.0
+
 module t();
    std::process proc;
    logic clk = 0;


### PR DESCRIPTION
This change fixes problems with updating state info of always processes.

In V3Timing, AstAlways visitor wasn't updating the current process pointer, so schedulers inside such processes were sometimes used as if the process didn't have a std::process instance.

Since schedulers use state info to detect killed processes, the bug would also affect killing always procs.
