### PR TITLE
Add support for referecing another argument in function argument default value

### DIFF
--- a/src/V3Scope.cpp
+++ b/src/V3Scope.cpp
@@ -297,6 +297,7 @@ private:
             m_varScopes.emplace(std::make_pair(nodep, m_scopep), varscp);
             m_scopep->addVarsp(varscp);
         }
+        iterateChildren(nodep);
     }
     void visit(AstVarRef* nodep) override {
         // VarRef needs to point to VarScope

--- a/test_regress/t/t_func_defaults.v
+++ b/test_regress/t/t_func_defaults.v
@@ -30,6 +30,11 @@ function int mult2(int x = Foo::get_x());
    return 2 * x;
 endfunction
 
+function int cond_func(int t,
+                       int p = t !== 1 ? 1 : 0);
+   return p;
+endfunction
+
 module t (/*AUTOARG*/);
    logic [1:0] foo_val;
 
@@ -41,6 +46,8 @@ module t (/*AUTOARG*/);
       if (mult2() != 0) $stop;
       Foo::x = 30;
       if (mult2() != 60) $stop;
+      if (cond_func(1) !== 0) $stop;
+      if (cond_func(2) !== 1) $stop;
 
       $write("*-* All Finished *-*\n");
       $finish;


### PR DESCRIPTION
This PR adds support for default values of arguments that references another argument of the function.

To take into account side-effects, first I create new temporary value in nearest ``AstNodeModule``, then I'm assigning value of referenced argument to it and replacing usage of this argument in both arguments (original one and referenced).
