### PR TITLE
Add JSON AST dumps

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -410,6 +410,7 @@ PY_PROGRAMS = \
 	src/cppcheck_filtered \
 	src/flexfix \
 	src/vlcovgen \
+	src/.gdbinit.py \
 	test_regress/t/*.pf \
 	nodist/clang_check_attributes \
 	nodist/code_coverage \

--- a/docs/CONTRIBUTORS
+++ b/docs/CONTRIBUTORS
@@ -157,6 +157,7 @@ Srinivasan Venkataramanan
 Stefan Wallentowitz
 Stephen Henry
 Steven Hugg
+Szymon Gizler
 Sören Tempel
 Teng Huang
 Tim Hutt

--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -1699,10 +1699,9 @@ Similarly, the ``NETLIST`` has a list of modules referred to by its
 .tree.json Output
 -----------------
 
-``.tree.json``` is alternative dump format (enabled with ``--dump-tree-json``)
-that is meant for programatic processing (see e.g. `verilator_jsontree` tool)
+``.tree.json``` is an alternative dump format to ``.tree`` that is meant for programmatic processing (e.g. with `astsee <https://github.com/antmicro/astsee>_`]). To enable this dump format, use ``--dump-tree-json``)
 
-Structure (note: plain output is unformatted):
+Structure:
 ::
 
   {
@@ -1737,34 +1736,6 @@ Structure (note: plain output is unformatted):
     op3: [ /* ... */ ],
     op4: [ /* ... */ ]
   }
-
-verilator_jsontree
-------------------
-``verilator_jsontree`` is tool that pretty prints, filters and diffs ``.tree.json`` files.
-The "pretty-print format" looks like this
-
-Structure:
-::
-
-  ...
-  MODULE "t" t_do_while.v:16:8 0x558a88b8ae90 <e1152> timeunit:1ps
-    op2:
-      VAR "a" t_do_while.v:17:8 0x558a88b8b370 <e633> attrClocker:UNKNOWN, ioDirection:NONE, lifetime:NONE, varType:VAR
-       op1:
-         BASICDTYPE "int" t_do_while.v:17:4 0x558a88b8b2a0 <e634> keyword:int, range:31:0
-      INITIAL "" t_do_while.v:18:4 0x558a88b96420 <e948>
-      ...
-
-* Order of fields: ``type``, ``name``, ``file``, ``addr``, ``editNum``, <node-specific-fields>, ``op1``, ``op2``, ``op3``, ``op4``.
-* For the sake of brevity, names of common fields (type, name, file, addr and editNum) are omitted.
-* Unless ``--verbose`` is used, node-specific fields with the value of false are omitted.
-* If there are no children in a given ``op*`` array then it is skipped.
-* ``name`` is often an empty string, so it is enclosed in quotes to make this case apparent.
-* Unwanted fields can be filtered out using the ``-d``` flag, for example ``-d '.file, .editNum'``.
-* In diffs, removed/added lines are colored, and replacements of inline fields are signaled with the ``->`` marker.
-* Unless ``--verbose`` is used, chunks of unmodified nodes are replaced with a ``...`` in diff
-
-To use jsontree, ``jq`` (a CLI utility) and ``DeepDiff`` (a Python library) have to be installed.
 
 .tree.dot Output
 ----------------
@@ -1838,17 +1809,19 @@ To print a node:
    pnt nodep
    # or: call dumpTreeGdb(nodep)  # aliased to "pnt" in src/.gdbinit
 
-``src/.gdbinit`` and ``src/.gdbinit.py`` define handy utils for working with
-JSON dumps. For example
+``src/.gdbinit`` and ``src/.gdbinit.py`` define handy utilities for working with
+JSON AST dumps. For example
 
-* ``jstash nodep`` - Do an unformatted JSON dump and save it into value history (e.g. ``$1``)
-* ``jtree nodep`` - Do a JSON dump and pretty print it using ``verilator_jsontree``.
+* ``jstash nodep`` - Perform a JSON AST dump and save it into GDB value history (e.g. ``$1``)
+* ``jtree nodep`` - Perform a JSON AST dump and pretty print it using ``astsee_verilator``.
 * ``jtree $1`` - Pretty print a dump that was previously saved by ``jstash``.
-* ``jtree nodep -d '.file, .timeunit'`` - Do a JSON dump, filter out some fields and pretty print it.
+* ``jtree nodep -d '.file, .timeunit'`` - Perform a JSON AST dump, filter out some fields and pretty print it.
 * ``jtree 0x55555613dca0`` - Pretty print using address literal (rather than actual pointer).
-* ``jtree $1 nodep`` - Diff ``nodep`` against its older dump.
+* ``jtree $1 nodep`` - Diff ``nodep`` against an older dump.
 
 A detailed description of ``jstash`` and ``jtree`` can be displayed using ``gdb``'s ``help`` command.
+
+These commands require `astsee <https://github.com/antmicro/astsee>_` to be installed.
 
 When GDB halts, it is useful to understand that the backtrace will commonly
 show the iterator functions between each invocation of ``visit`` in the

--- a/src/.gdbinit
+++ b/src/.gdbinit
@@ -33,8 +33,8 @@ define jstash
   call (char*) &(AstNode::dumpJsonTreeGdb($arg0)[0])
 end
 document jstash
-Verilator: Do json dump of the given nodep and save it in value history (e.g. $1) for later
-inspection using jtree. nodep can be actual pointer or adress literal (like 0x55555613dca0).
+Verilator: Perform a JSON dump of the given AST node and save it in value history (e.g. $1) for later
+inspection using jtree. The node can be a pointer identifier or an address literal.
 end
 
 alias -a js=jstash

--- a/src/.gdbinit
+++ b/src/.gdbinit
@@ -20,6 +20,26 @@ document pnt
   Verilator: Print AstNode NODEP's tree
 end
 
+# source python-based gdb config with jshow/jdiff definitions
+# (we store it in separate file, so it can be highlighted/linted/formatted as python)
+python
+import os
+if "VERILATOR_ROOT" in os.environ:
+  gdbinit_py = os.environ["VERILATOR_ROOT"] + "/src/.gdbinit.py"
+  gdb.execute("source" + gdbinit_py)
+end
+
+define jstash
+  call (char*) &(AstNode::dumpJsonTreeGdb($arg0)[0])
+end
+document jstash
+Verilator: Do json dump of the given nodep and save it in value history (e.g. $1) for later
+inspection using jtree. nodep can be actual pointer or adress literal (like 0x55555613dca0).
+end
+
+alias -a js=jstash
+alias -a jt=jtree
+
 define dtf
   call AstNode::dumpTreeFileGdb($arg0, 0)
 end

--- a/src/.gdbinit.py
+++ b/src/.gdbinit.py
@@ -1,0 +1,68 @@
+# pylint: disable=line-too-long,invalid-name,multiple-statements,missing-function-docstring,missing-class-docstring,missing-module-docstring,no-else-return,too-few-public-methods,unused-argument
+import os
+import sys
+import tempfile
+
+import gdb  # pylint: disable=import-error
+
+# add dir with verilator_jsontree to import path
+sys.path.append(os.environ["VERILATOR_ROOT"] + "/bin")
+
+
+def _get_dump(node):
+    return gdb.execute(f'printf "%s", &(AstNode::dumpJsonTreeGdb({node})[0])',
+                       to_string=True)
+
+
+def _tmpfile():
+    return tempfile.NamedTemporaryFile(mode="wt")  # write, text mode
+
+
+def _fwrite(file, s):
+    """write to file and flush buf to make sure that data is written before passing file to jsontree"""
+    file.write(s)
+    file.flush()
+
+
+class JsonTreeCmd(gdb.Command):
+    """Verilator: Pretty print or diff node(s) using jsontree. Node is allowed to be:
+    * an actual pointer,
+    * an address literal (like 0x55555613dca0),
+    * a gdb value (like $1) that stores a dump previously done by the jstash command.
+    Besides not taking input from file, it works exactly like `verilator_jsontree`:
+    * passing one node gives you a pretty print,
+    * passing two nodes gives you a diff,
+    * flags like -d work like expected.
+    """
+
+    def __init__(self):
+        super().__init__("jtree", gdb.COMMAND_USER, gdb.COMPLETE_EXPRESSION)
+
+    def _null_check(self, old, new):
+        err = ""
+        if old == "<nullptr>\n": err += "old == <nullptr>\n"
+        if new == "<nullptr>\n": err += "new == <nullptr>"
+        if err: raise gdb.GdbError(err.strip("\n"))
+
+    def invoke(self, arg_str, from_tty):
+        import verilator_jsontree as jsontree  # pylint: disable=wrong-import-position
+        # jsontree import may fail so we do it here rather than in outer scope
+
+        # We abuse verilator_jsontree's arg parser to find arguments with nodes
+        # After finding them, we replace them with proper files
+        jsontree_args = jsontree.parser.parse_args(gdb.string_to_argv(arg_str))
+        self._null_check(jsontree_args.file, jsontree_args.newfile)
+        with _tmpfile() as oldfile, _tmpfile() as newfile:
+            if jsontree_args.file:
+                _fwrite(oldfile, _get_dump(jsontree_args.file))
+                jsontree_args.file = oldfile.name
+            if jsontree_args.newfile:
+                _fwrite(newfile, _get_dump(jsontree_args.newfile))
+                jsontree_args.newfile = newfile.name
+            try:
+                jsontree.main(jsontree_args)
+            except SystemExit:  # jsontree prints nice errmsgs on exit(), so we just catch it to suppress cryptic python trace
+                return
+
+
+JsonTreeCmd()

--- a/src/.gdbinit.py
+++ b/src/.gdbinit.py
@@ -48,7 +48,7 @@ class JsonTreeCmd(gdb.Command):
         import verilator_jsontree as jsontree  # pylint: disable=wrong-import-position
         # jsontree import may fail so we do it here rather than in outer scope
 
-        # We abuse verilator_jsontree's arg parser to find arguments with nodes
+        # We hack `astsee_verilator`'s arg parser to find arguments with nodes
         # After finding them, we replace them with proper files
         jsontree_args = jsontree.parser.parse_args(gdb.string_to_argv(arg_str))
         self._null_check(jsontree_args.file, jsontree_args.newfile)

--- a/src/.gdbinit.py
+++ b/src/.gdbinit.py
@@ -19,20 +19,20 @@ def _tmpfile():
 
 
 def _fwrite(file, s):
-    """write to file and flush buf to make sure that data is written before passing file to jsontree"""
+    """Write to file and flush buffer before passing the file to astsee"""
     file.write(s)
     file.flush()
 
 
 class JsonTreeCmd(gdb.Command):
-    """Verilator: Pretty print or diff node(s) using jsontree. Node is allowed to be:
-    * an actual pointer,
-    * an address literal (like 0x55555613dca0),
-    * a gdb value (like $1) that stores a dump previously done by the jstash command.
-    Besides not taking input from file, it works exactly like `verilator_jsontree`:
+    """Verilator: Pretty print or diff nodes using `astsee`. A node can be:
+    * an pointer identifier,
+    * an address literal,
+    * a GDB value (like `$1`) that stores a dump previously done by the `jstash` command.
+    Apart from not taking input from a file, it works exactly like `astsee`:
     * passing one node gives you a pretty print,
     * passing two nodes gives you a diff,
-    * flags like -d work like expected.
+    * for more options see `astsee` readme/help.
     """
 
     def __init__(self):

--- a/src/V3Ast.h
+++ b/src/V3Ast.h
@@ -31,6 +31,7 @@
 #include "V3Ast__gen_forward_class_decls.h"  // From ./astgen
 
 #include <cmath>
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <set>
@@ -2161,6 +2162,9 @@ public:
     string warnOther() const VL_REQUIRES(V3Error::s().m_mutex) { return fileline()->warnOther(); }
 
     virtual void dump(std::ostream& str = std::cout) const;
+    static std::string dumpJsonTreeGdb(const AstNode* nodep);  // For GDB only
+    static const char* dumpJsonTreeGdb(const char* str);  // For GDB only
+    static std::string dumpJsonTreeGdb(intptr_t nodep);  // For GDB only
     static void dumpGdb(const AstNode* nodep);  // For GDB only
     void dumpGdbHeader() const;
 
@@ -2216,6 +2220,9 @@ public:
     static void dumpTreeFileGdb(const AstNode* nodep, const char* filenamep = nullptr);
     void dumpTreeDot(std::ostream& os = std::cout) const;
     void dumpTreeDotFile(const string& filename, bool append = false, bool doDump = true);
+    virtual void dumpExtraJson(std::ostream& os) const {};  // node specific fields
+    void dumpTreeJson(std::ostream& os) const;
+    void dumpTreeJsonFile(const string& filename, bool append = false, bool doDump = true);
 
     // METHODS - static advancement
     static AstNode* afterCommentp(AstNode* nodep) {

--- a/src/V3AstNodeDType.h
+++ b/src/V3AstNodeDType.h
@@ -52,6 +52,7 @@ public:
     ASTGEN_MEMBERS_AstNodeDType;
     // ACCESSORS
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     virtual void dumpSmall(std::ostream& str) const;
     bool hasDType() const override { return true; }
     /// Require VlUnpacked, instead of [] for POD elements.
@@ -148,6 +149,7 @@ protected:
 public:
     ASTGEN_MEMBERS_AstNodeArrayDType;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     void dumpSmall(std::ostream& str) const override;
     const char* broken() const override {
         BROKEN_RTN(!((m_refDTypep && !childDTypep() && m_refDTypep->brokeExists())
@@ -217,6 +219,7 @@ public:
     int uniqueNum() const { return m_uniqueNum; }
     const char* broken() const override;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool isCompound() const override { return !packed(); }
     // For basicp() we reuse the size to indicate a "fake" basic type of same size
     AstBasicDType* basicp() const override {
@@ -387,6 +390,7 @@ private:
 public:
     ASTGEN_MEMBERS_AstBasicDType;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     // width/widthMin/numeric compared elsewhere
     bool same(const AstNode* samep) const override;
     bool similarDType(const AstNodeDType* samep) const override {
@@ -548,6 +552,7 @@ public:
         return this == samep || (type() == samep->type() && same(samep));
     }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     string name() const override VL_MT_STABLE;
     AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
@@ -813,6 +818,7 @@ public:
     string name() const override VL_MT_STABLE { return m_name; }
     void name(const string& flag) override { m_name = flag; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     // METHODS
     AstBasicDType* basicp() const override VL_MT_STABLE { return subDTypep()->basicp(); }
@@ -867,6 +873,7 @@ public:
     // METHODS
     const char* broken() const override;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     void cloneRelink() override;
     AstBasicDType* basicp() const override VL_MT_STABLE { return nullptr; }
@@ -982,6 +989,7 @@ public:
     }
     ASTGEN_MEMBERS_AstParamTypeDType;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
     AstNodeDType* subDTypep() const override VL_MT_STABLE {
         return dtypep() ? dtypep() : childDTypep();
@@ -1135,6 +1143,7 @@ public:
         return skipRefp()->similarDType(samep->skipRefp());
     }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     void dumpSmall(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     string prettyDTypeName() const override {

--- a/src/V3AstNodeExpr.h
+++ b/src/V3AstNodeExpr.h
@@ -50,6 +50,7 @@ public:
     ASTGEN_MEMBERS_AstNodeExpr;
     // METHODS
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     // TODO: The only AstNodeExpr without dtype is AstArg. Otherwise this could be final.
     bool hasDType() const override { return true; }
     virtual string emitVerilog() = 0;  /// Format string for verilog writing; see V3EmitV
@@ -195,6 +196,7 @@ protected:
 public:
     ASTGEN_MEMBERS_AstNodeCCall;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     void cloneRelink() override;
     const char* broken() const override;
     int instrCount() const override { return INSTR_COUNT_CALL; }
@@ -248,6 +250,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     string name() const override VL_MT_STABLE { return m_name; }  // * = Var name
     bool isGateOptimizable() const override;
     string dotted() const { return m_dotted; }  // * = Scope name or ""
@@ -357,6 +360,7 @@ public:
     // cppcheck-suppress functionConst
     void iterateChildren(VNVisitorConst& v) {}
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
 };
 class AstNodeTriop VL_NOT_FINAL : public AstNodeExpr {
     // Ternary expression
@@ -377,6 +381,7 @@ public:
     ASTGEN_MEMBERS_AstNodeTriop;
     // METHODS
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     // Set out to evaluation of a AstConst'ed
     virtual void numberOperate(V3Number& out, const V3Number& lhs, const V3Number& rhs,
                                const V3Number& ths)
@@ -458,6 +463,7 @@ public:
     ASTGEN_MEMBERS_AstNodeUniop;
     // METHODS
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     // Set out to evaluation of a AstConst'ed lhs
     virtual void numberOperate(V3Number& out, const V3Number& lhs) = 0;
     virtual bool cleanLhs() const = 0;
@@ -509,6 +515,7 @@ protected:
 public:
     ASTGEN_MEMBERS_AstNodeVarRef;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     const char* broken() const override;
     int instrCount() const override { return widthInstrs(); }
     void cloneRelink() override;
@@ -594,6 +601,7 @@ public:
     ASTGEN_MEMBERS_AstAttrOf;
     VAttrType attrType() const { return m_attrType; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
 
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
     string emitC() override { V3ERROR_NA_RETURN(""); }
@@ -777,6 +785,7 @@ public:
                 == VN_DBG_AS(samep, ClassOrPackageRef)->m_classOrPackageNodep);
     }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     string name() const override VL_MT_STABLE { return m_name; }  // * = Var name
     AstNode* classOrPackageNodep() const { return m_classOrPackageNodep; }
     void classOrPackageNodep(AstNode* nodep) { m_classOrPackageNodep = nodep; }
@@ -1131,6 +1140,7 @@ public:
         return new AstDot{fl, true, packageOrClassp, rhsp};
     }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool colon() const { return m_colon; }
 
     string emitVerilog() override { V3ERROR_NA_RETURN(""); }
@@ -1159,6 +1169,7 @@ public:
     }
     ASTGEN_MEMBERS_AstEnumItemRef;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return itemp()->name(); }
     int instrCount() const override { return 0; }
     const char* broken() const override;
@@ -1438,6 +1449,9 @@ public:
 
 private:
     KeyItemMap m_map;  // Node value for each array index
+    // METHODS
+    void dumpInitList(std::ostream& str) const;
+
 public:
     AstInitArray(FileLine* fl, AstNodeDType* newDTypep, AstNodeExpr* defaultp)
         : ASTGEN_SUPER_InitArray(fl) {
@@ -1446,6 +1460,7 @@ public:
     }
     ASTGEN_MEMBERS_AstInitArray;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     const char* broken() const override;
     void cloneRelink() override;
     bool same(const AstNode* samep) const override {
@@ -1538,6 +1553,7 @@ public:
     void cloneRelink() override;
     const char* broken() const override;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     void name(const string& name) override { m_name = name; }
     VAccess access() const { return m_access; }
@@ -1605,6 +1621,7 @@ public:
     }
     ASTGEN_MEMBERS_AstParseRef;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }  // * = Var name
     bool same(const AstNode* samep) const override {
         const AstParseRef* const asamep = VN_DBG_AS(samep, ParseRef);
@@ -1661,6 +1678,7 @@ public:
     bool cleanOut() const override { V3ERROR_NA_RETURN(""); }
     int instrCount() const override { return widthInstrs() * 2; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     bool isDefault() const { return m_default; }
     void isDefault(bool flag) { m_default = flag; }
 };
@@ -1891,6 +1909,7 @@ public:
     string emitC() override { V3ERROR_NA_RETURN(""); }
     bool cleanOut() const override { return true; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     string scopeSymName() const {  // Name for __Vscope variable including children
         return scopeNameFormatter(scopeAttrp());
     }
@@ -4374,6 +4393,7 @@ public:
     int instrCount() const override { return INSTR_COUNT_TIME; }
     bool same(const AstNode* /*samep*/) const override { return true; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     void timeunit(const VTimescale& flag) { m_timeunit = flag; }
     VTimescale timeunit() const { return m_timeunit; }
 };
@@ -4394,6 +4414,7 @@ public:
     int instrCount() const override { return INSTR_COUNT_TIME; }
     bool same(const AstNode* /*samep*/) const override { return true; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     void timeunit(const VTimescale& flag) { m_timeunit = flag; }
     VTimescale timeunit() const { return m_timeunit; }
 };
@@ -4542,6 +4563,7 @@ public:
     }
     ASTGEN_MEMBERS_AstSel;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     void numberOperate(V3Number& out, const V3Number& from, const V3Number& bit,
                        const V3Number& width) override {
         out.opSel(from, bit.toUInt() + width.toUInt() - 1, bit.toUInt());
@@ -4582,6 +4604,7 @@ public:
         , m_declRange{declRange} {}
     ASTGEN_MEMBERS_AstSliceSel;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     void numberOperate(V3Number& out, const V3Number& from, const V3Number& lo,
                        const V3Number& width) override {
         V3ERROR_NA;
@@ -4745,6 +4768,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     AstSenTree* sensesp() const { return m_sensesp; }
     void clearSensesp() { m_sensesp = nullptr; }
     void numberOperate(V3Number& out, const V3Number& lhs) override { V3ERROR_NA; }
@@ -4783,6 +4807,7 @@ public:
         return size() == VN_DBG_AS(samep, CCast)->size();
     }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     //
     int size() const { return m_size; }
 };
@@ -5275,6 +5300,7 @@ public:
     bool cleanLhs() const override { return false; }
     bool sizeMattersLhs() const override { return false; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     void timeunit(const VTimescale& flag) { m_timeunit = flag; }
     VTimescale timeunit() const { return m_timeunit; }
 };
@@ -5541,6 +5567,7 @@ public:
     ASTGEN_MEMBERS_AstVarRef;
     inline string name() const override;  // * = Var name
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     const char* broken() const override;
     bool same(const AstNode* samep) const override;
     inline bool same(const AstVarRef* samep) const;
@@ -5565,6 +5592,7 @@ public:
     ASTGEN_MEMBERS_AstVarXRef;
     string name() const override VL_MT_STABLE { return m_name; }  // * = Var name
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string dotted() const { return m_dotted; }
     void dotted(const string& dotted) { m_dotted = dotted; }
     string inlinedDots() const { return m_inlinedDots; }

--- a/src/V3AstNodeOther.h
+++ b/src/V3AstNodeOther.h
@@ -47,6 +47,7 @@ protected:
 public:
     ASTGEN_MEMBERS_AstNodeBlock;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }  // * = Block name
     void name(const string& name) override { m_name = name; }
     bool unnamed() const { return m_unnamed; }
@@ -123,6 +124,7 @@ public:
     ASTGEN_MEMBERS_AstNodeFTask;
     virtual AstNodeFTask* cloneType(const string& name) = 0;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     string name() const override VL_MT_STABLE { return m_name; }  // * = Var name
     bool maybePointedTo() const override { return true; }
     bool isGateOptimizable() const override {
@@ -210,6 +212,7 @@ public:
         , m_name{name} {}
     ASTGEN_MEMBERS_AstNodeFile;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     bool same(const AstNode* /*samep*/) const override { return true; }
 };
@@ -258,6 +261,7 @@ protected:
 public:
     ASTGEN_MEMBERS_AstNodeModule;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool maybePointedTo() const override { return true; }
     string name() const override VL_MT_STABLE { return m_name; }
     virtual bool timescaleMatters() const = 0;
@@ -313,6 +317,7 @@ public:
     ASTGEN_MEMBERS_AstNodeProcedure;
     // METHODS
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool isJustOneBodyStmt() const { return stmtsp() && !stmtsp()->nextp(); }
     bool isSuspendable() const { return m_suspendable; }
     void setSuspendable() { m_suspendable = true; }
@@ -328,6 +333,7 @@ protected:
 public:
     ASTGEN_MEMBERS_AstNodeRange;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
 };
 class AstNodeStmt VL_NOT_FINAL : public AstNode {
     // Procedural statement
@@ -341,6 +347,7 @@ public:
     void addNextStmt(AstNode* newp,
                      AstNode* belowp) override;  // Stop statement searchback here
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
 };
 class AstNodeAssign VL_NOT_FINAL : public AstNodeStmt {
     // Iteration is in order, and we want rhsp to be visited first (which is the execution order)
@@ -407,6 +414,7 @@ public:
     bool same(const AstNode* samep) const override { return samep->name() == name(); }
     void name(const string& name) override { m_name = name; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     bool immediate() const { return m_immediate; }
 };
 class AstNodeFor VL_NOT_FINAL : public AstNodeStmt {
@@ -505,6 +513,8 @@ public:
 };
 class AstNodeText VL_NOT_FINAL : public AstNode {
     string m_text;
+    // METHODS
+    string shortText() const;
 
 protected:
     // Node that puts text into the output stream
@@ -515,6 +525,7 @@ protected:
 public:
     ASTGEN_MEMBERS_AstNodeText;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     bool same(const AstNode* samep) const override {
         const AstNodeText* asamep = VN_DBG_AS(samep, NodeText);
         return text() == asamep->text();
@@ -553,6 +564,7 @@ public:
     }
     ASTGEN_MEMBERS_AstActive;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     const char* broken() const override;
     void cloneRelink() override;
@@ -655,6 +667,7 @@ public:
     void cloneRelink() override;
     bool maybePointedTo() const override { return true; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     bool same(const AstNode* samep) const override {
         const AstCFunc* const asamep = VN_DBG_AS(samep, CFunc);
         return ((isTrace() == asamep->isTrace()) && (rtnTypeVoid() == asamep->rtnTypeVoid())
@@ -758,6 +771,7 @@ public:
         , m_useType{useType} {}
     ASTGEN_MEMBERS_AstCUse;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     VUseType useType() const { return m_useType; }
 };
@@ -810,6 +824,7 @@ public:
     ASTGEN_MEMBERS_AstCell;
     // No cloneRelink, we presume cloneee's want the same module linkages
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     const char* broken() const override;
     bool maybePointedTo() const override { return true; }
     // ACCESSORS
@@ -851,6 +866,7 @@ public:
         , m_timeunit{timeunit} {}
     ASTGEN_MEMBERS_AstCellInline;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     const char* broken() const override;
     // ACCESSORS
     string name() const override VL_MT_STABLE { return m_name; }  // * = Cell name
@@ -878,6 +894,7 @@ public:
     }
     ASTGEN_MEMBERS_AstClassExtends;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool hasDType() const override { return true; }
     string verilogKwd() const override { return isImplements() ? "implements" : "extends"; }
     // Class being extended (after link and instantiation if needed)
@@ -910,6 +927,7 @@ public:
     }
     ASTGEN_MEMBERS_AstClocking;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     std::string name() const override VL_MT_STABLE { return m_name; }
     bool isDefault() const { return m_isDefault; }
     bool isGlobal() const { return m_isGlobal; }
@@ -1173,6 +1191,7 @@ public:
     ExecMTask* execMTaskp() const { return m_execMTaskp; }
     void execMTaskp(ExecMTask* execMTaskp) { m_execMTaskp = execMTaskp; }
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
 };
 class AstModport final : public AstNode {
     // A modport in an interface
@@ -1205,6 +1224,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     bool isImport() const { return !m_export; }
     bool isExport() const { return m_export; }
@@ -1227,6 +1247,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     void direction(const VDirection& flag) { m_direction = flag; }
     VDirection direction() const { return m_direction; }
@@ -1265,6 +1286,7 @@ public:
     void cloneRelink() override { V3ERROR_NA; }
     string name() const override VL_MT_STABLE { return "$root"; }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     AstNodeModule* topModulep() const VL_MT_STABLE {  // Top module in hierarchy
         return modulesp();  // First one in the list, for now
     }
@@ -1315,6 +1337,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     AstPackage* packagep() const { return m_packagep; }
     void packagep(AstPackage* nodep) { m_packagep = nodep; }
@@ -1340,6 +1363,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string name() const override VL_MT_STABLE { return m_name; }
     AstPackage* packagep() const { return m_packagep; }
     void packagep(AstPackage* nodep) { m_packagep = nodep; }
@@ -1364,6 +1388,7 @@ public:
     inline AstPin(FileLine* fl, int pinNum, AstVarRef* varname, AstNode* exprp);
     ASTGEN_MEMBERS_AstPin;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     const char* broken() const override;
     string name() const override VL_MT_STABLE { return m_name; }  // * = Pin name, ""=go by number
     void name(const string& name) override { m_name = name; }
@@ -1474,6 +1499,7 @@ public:
     string name() const override VL_MT_STABLE { return m_name; }  // * = Scope name
     void name(const string& name) override { m_name = name; }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool same(const AstNode* samep) const override;
     string nameDotless() const;
     AstNodeModule* modp() const { return m_modp; }
@@ -1522,6 +1548,7 @@ public:
         , m_edgeType{VEdgeType::ET_NEVER} {}
     ASTGEN_MEMBERS_AstSenItem;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool same(const AstNode* samep) const override {
         return edgeType() == VN_DBG_AS(samep, SenItem)->edgeType();
     }
@@ -1552,6 +1579,7 @@ public:
     }
     ASTGEN_MEMBERS_AstSenTree;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool maybePointedTo() const override { return true; }
     bool isMulti() const { return m_multi; }
     void multi(bool flag) { m_multi = true; }
@@ -1584,6 +1612,7 @@ public:
     VStrength strength0() { return m_s0; }
     VStrength strength1() { return m_s1; }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
 };
 class AstTopScope final : public AstNode {
     // A singleton, held under the top level AstModule. Holds the top level
@@ -1641,6 +1670,7 @@ public:
     void clearCache();
     void repairCache();
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
 };
 class AstTypedef final : public AstNode {
     // @astgen op1 := childDTypep : Optional[AstNodeDType]
@@ -1661,6 +1691,7 @@ public:
     }
     ASTGEN_MEMBERS_AstTypedef;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     AstNodeDType* getChildDTypep() const override { return childDTypep(); }
     virtual AstNodeDType* subDTypep() const VL_MT_STABLE {
         return dtypep() ? dtypep() : childDTypep();
@@ -1867,6 +1898,7 @@ public:
     }
     ASTGEN_MEMBERS_AstVar;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool same(const AstNode* samep) const override;
     string name() const override VL_MT_STABLE VL_MT_SAFE { return m_name; }  // * = Var name
     bool hasDType() const override { return true; }
@@ -2122,6 +2154,7 @@ public:
     bool maybePointedTo() const override { return true; }
     string name() const override VL_MT_STABLE { return scopep()->name() + "->" + varp()->name(); }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool same(const AstNode* samep) const override;
     bool hasDType() const override { return true; }
     AstVar* varp() const VL_MT_STABLE { return m_varp; }  // [After Link] Pointer to variable
@@ -2150,6 +2183,7 @@ public:
         , m_implied{implied} {}
     ASTGEN_MEMBERS_AstBegin;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     void generate(bool flag) { m_generate = flag; }
     bool generate() const { return m_generate; }
     void setNeedProcess() { m_needProcess = true; }
@@ -2169,6 +2203,7 @@ public:
     ASTGEN_MEMBERS_AstFork;
     bool isTimingControl() const override { return !joinType().joinNone(); }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     VJoinType joinType() const { return m_joinType; }
     void joinType(const VJoinType& flag) { m_joinType = flag; }
 };
@@ -2239,6 +2274,7 @@ public:
         , m_support{false} {}
     ASTGEN_MEMBERS_AstCFile;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
     bool slow() const { return m_slow; }
     void slow(bool flag) { m_slow = flag; }
     bool source() const { return m_source; }
@@ -2254,6 +2290,7 @@ public:
         : ASTGEN_SUPER_VFile(fl, name) {}
     ASTGEN_MEMBERS_AstVFile;
     void dump(std::ostream& str = std::cout) const override;
+    void dumpExtraJson(std::ostream& str = std::cout) const override;
 };
 
 // === AstNodeModule ===
@@ -2274,6 +2311,7 @@ public:
     string verilogKwd() const override { return "class"; }
     bool maybePointedTo() const override { return true; }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     const char* broken() const override;
     void cloneRelink() override;
     bool timescaleMatters() const override { return false; }
@@ -2379,6 +2417,7 @@ public:
     ASTGEN_MEMBERS_AstAlways;
     //
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     VAlwaysKwd keyword() const { return m_keyword; }
 };
 class AstAlwaysObserved final : public AstNodeProcedure {
@@ -2496,6 +2535,7 @@ public:
     int elementsConst() const VL_MT_STABLE { return hiConst() - loConst() + 1; }
     bool ascending() const { return leftConst() < rightConst(); }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     virtual string emitC() { V3ERROR_NA_RETURN(""); }
     bool same(const AstNode* /*samep*/) const override { return true; }
 };
@@ -2673,6 +2713,7 @@ public:
         if (m_dataDeclp && m_dataDeclp->clonep()) m_dataDeclp = m_dataDeclp->clonep();
     }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     int instrCount() const override { return 1 + 2 * INSTR_COUNT_LD; }
     bool maybePointedTo() const override { return true; }
     void binNum(int flag) { m_binNum = flag; }
@@ -2712,6 +2753,7 @@ public:
         if (m_declp->clonep()) m_declp = m_declp->clonep();
     }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     int instrCount() const override { return 1 + 2 * INSTR_COUNT_LD; }
     bool same(const AstNode* samep) const override {
         return declp() == VN_DBG_AS(samep, CoverInc)->declp();
@@ -2759,6 +2801,7 @@ public:
     }
     ASTGEN_MEMBERS_AstDelay;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     bool isTimingControl() const override { return true; }
     bool isCycleDelay() const { return m_isCycle; }
     bool same(const AstNode* /*samep*/) const override { return true; }
@@ -2806,6 +2849,7 @@ public:
     }
     ASTGEN_MEMBERS_AstDisplay;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     const char* broken() const override {
         BROKEN_RTN(!fmtp());
         return nullptr;
@@ -2978,6 +3022,7 @@ public:
     const char* broken() const override;
     void cloneRelink() override;
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     int instrCount() const override { return INSTR_COUNT_BRANCH; }
     bool same(const AstNode* samep) const override {
         return labelp() == VN_DBG_AS(samep, JumpGo)->labelp();
@@ -3008,6 +3053,7 @@ public:
         if (m_blockp->clonep()) m_blockp = m_blockp->clonep();
     }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     int instrCount() const override { return 0; }
     bool same(const AstNode* samep) const override {
         return blockp() == VN_DBG_AS(samep, JumpLabel)->blockp();
@@ -3044,6 +3090,7 @@ public:
     void name(const string& name) override { m_name = name; }
     string name() const override VL_MT_STABLE { return m_name; }  // * = Var name
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     string verilogKwd() const override { return "$printtimescale"; }
     bool isGateOptimizable() const override { return false; }
     bool isPredictOptimizable() const override { return false; }
@@ -3257,6 +3304,7 @@ public:
         this->valuep(valuep);
     }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     int instrCount() const override { return 100; }  // Large...
     ASTGEN_MEMBERS_AstTraceDecl;
     string name() const override VL_MT_STABLE { return m_showname; }
@@ -3303,6 +3351,7 @@ public:
         if (m_declp->clonep()) m_declp = m_declp->clonep();
     }
     void dump(std::ostream& str) const override;
+    void dumpExtraJson(std::ostream& str) const override;
     int instrCount() const override { return 10 + 2 * INSTR_COUNT_LD; }
     bool hasDType() const override { return true; }
     bool same(const AstNode* samep) const override {

--- a/src/V3AstNodes.cpp
+++ b/src/V3AstNodes.cpp
@@ -2,7 +2,7 @@
 //*************************************************************************
 // DESCRIPTION: Verilator: Ast node structures
 //
-    // Code available from: https://verilator.org
+// Code available from: https://verilator.org
 //
 //*************************************************************************
 //

--- a/src/V3Global.cpp
+++ b/src/V3Global.cpp
@@ -107,6 +107,9 @@ string V3Global::digitsFilename(int number) {
 void V3Global::dumpCheckGlobalTree(const string& stagename, int newNumber, bool doDump) {
     const string treeFilename = v3Global.debugFilename(stagename + ".tree", newNumber);
     v3Global.rootp()->dumpTreeFile(treeFilename, false, doDump);
+    if (v3Global.opt.dumpTreeJson()) {
+        v3Global.rootp()->dumpTreeJsonFile(treeFilename + ".json", false, doDump);
+    }
     if (v3Global.opt.dumpTreeDot()) {
         v3Global.rootp()->dumpTreeDotFile(treeFilename + ".dot", false, doDump);
     }

--- a/src/V3Options.cpp
+++ b/src/V3Options.cpp
@@ -898,9 +898,20 @@ void V3Options::notify() VL_MT_DISABLED {
     // Mark options as available
     m_available = true;
 
+    // --dump-json-tree will serve as alias to --dump-tree-json. Rationale is that:
+    //  - It is easy typo to make (after all tool used for pretty printing is called jsontree)
+    //  - Parsing of dump* options is very "forgiving" and does not report error when non-existing
+    //    option is used
+    if (m_dumpLevel.count("json-tree")) m_dumpLevel["tree-json"] = m_dumpLevel["json-tree"];
+
     // --dump-tree-dot will turn on tree dumping.
     if (!m_dumpLevel.count("tree") && m_dumpLevel.count("tree-dot")) {
         m_dumpLevel["tree"] = m_dumpLevel["tree-dot"];
+    }
+
+    // --dump-tree-json will turn on tree dumping.
+    if (!m_dumpLevel.count("tree") && m_dumpLevel.count("tree-json")) {
+        m_dumpLevel["tree"] = m_dumpLevel["tree-json"];
     }
 
     // Sanity check of expected configuration

--- a/src/V3Options.h
+++ b/src/V3Options.h
@@ -472,6 +472,9 @@ public:
     bool decoration() const VL_MT_SAFE { return m_decoration; }
     bool dpiHdrOnly() const { return m_dpiHdrOnly; }
     bool dumpDefines() const { return m_dumpLevel.count("defines") && m_dumpLevel.at("defines"); }
+    bool dumpTreeJson() const {
+        return m_dumpLevel.count("tree-json") && m_dumpLevel.at("tree-json");
+    }
     bool dumpTreeDot() const {
         return m_dumpLevel.count("tree-dot") && m_dumpLevel.at("tree-dot");
     }


### PR DESCRIPTION
Verilator's AST can currently be dumped into custom `.tree` representation for debug purposes. This PR adds a mostly equivalent JSON representation which is easier to process programmatically.

## Example use cases

### Tree diffing
An example of how this is useful is the [`astsee`](https://github.com/antmicro/astsee) tool which can pretty-print and diff these JSON dumps.
![diff](https://github.com/antmicro/verilator-1/assets/9216518/4a07ef4f-8b9a-47d7-9c72-181ae6125af5)

### Tree navigation
An example HTML representation for easy navigation of the AST:
[example.zip](https://github.com/antmicro/verilator-1/files/13439928/example.zip)

### GDB commands
`astsee` can also be used from within GDB. Useful for diffing the AST at runtime, even within a single Verilator stage.
![gdb](https://github.com/antmicro/verilator-1/assets/9216518/f1821899-2e09-40c2-b898-dc31300141b3)